### PR TITLE
Support for Arbitrarily Big Integers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "som-core 0.1.0",
  "som-lexer 0.1.0",

--- a/som-core/src/ast.rs
+++ b/som-core/src/ast.rs
@@ -237,6 +237,8 @@ pub enum Literal {
     Double(f64),
     /// Represents a integer number literal (eg. `42`).
     Integer(i64),
+    /// Represents a big integer (bigger than a 64-bit signed integer can represent).
+    BigInteger(String),
     /// Represents an array literal (eg. `$(1 2 3)`)
     Array(Vec<Literal>),
 }

--- a/som-interpreter/Cargo.toml
+++ b/som-interpreter/Cargo.toml
@@ -32,6 +32,7 @@ indexmap = "1.4.0"
 
 # big integers
 num-bigint = "0.2.6"
+num-traits = "0.2.11"
 
 # random numbers
 rand = "0.7.3"

--- a/som-interpreter/src/evaluate.rs
+++ b/som-interpreter/src/evaluate.rs
@@ -127,6 +127,10 @@ impl Evaluate for ast::Literal {
                 Return::Local(Value::Array(Rc::new(RefCell::new(output))))
             }
             Self::Integer(int) => Return::Local(Value::Integer(*int)),
+            Self::BigInteger(int) => match int.parse() {
+                Ok(value) => Return::Local(Value::BigInteger(value)),
+                Err(err) => Return::Exception(err.to_string()),
+            },
             Self::Double(double) => Return::Local(Value::Double(*double)),
             Self::Symbol(sym) => Return::Local(Value::Symbol(universe.intern_symbol(sym))),
             Self::String(string) => Return::Local(Value::String(Rc::new(string.clone()))),

--- a/som-interpreter/src/hashcode.rs
+++ b/som-interpreter/src/hashcode.rs
@@ -23,6 +23,10 @@ impl Hash for Value {
                 hasher.write(b"#int#");
                 value.hash(hasher);
             }
+            Value::BigInteger(value) => {
+                hasher.write(b"#bigint#");
+                value.hash(hasher);
+            }
             Value::Double(value) => {
                 hasher.write(b"#double#");
                 let raw_bytes: &[u8] = unsafe {
@@ -42,7 +46,7 @@ impl Hash for Value {
                 value.hash(hasher);
             }
             Value::Array(value) => {
-                hasher.write(b"#int#");
+                hasher.write(b"#arr#");
                 for value in value.borrow().iter() {
                     value.hash(hasher);
                 }
@@ -88,7 +92,7 @@ impl Hash for Instance {
 }
 
 impl Hash for Block {
-    fn hash<H: Hasher>(&self, hasher: &mut H) {
+    fn hash<H: Hasher>(&self, _hasher: &mut H) {
         todo!()
     }
 }

--- a/som-interpreter/src/primitives/integer.rs
+++ b/som-interpreter/src/primitives/integer.rs
@@ -349,8 +349,12 @@ fn lt(_: &mut Universe, args: Vec<Value>) -> Return {
         (Value::Integer(a), Value::Double(b)) | (Value::Double(b), Value::Integer(a)) => {
             Return::Local(Value::Boolean((a as f64) < b))
         }
-        (Value::BigInteger(a), Value::Integer(b)) => Return::Local(Value::Boolean(a < BigInt::from(b))),
-        (Value::Integer(a), Value::BigInteger(b)) => Return::Local(Value::Boolean(b < BigInt::from(a))),
+        (Value::BigInteger(a), Value::Integer(b)) => {
+            Return::Local(Value::Boolean(a < BigInt::from(b)))
+        }
+        (Value::Integer(a), Value::BigInteger(b)) => {
+            Return::Local(Value::Boolean(b < BigInt::from(a)))
+        }
         (a, b) => {
             return Return::Exception(format!("'{}': wrong types ({:?} | {:?})", SIGNATURE, a, b))
         }

--- a/som-interpreter/src/primitives/integer.rs
+++ b/som-interpreter/src/primitives/integer.rs
@@ -202,8 +202,6 @@ fn divide(_: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "Integer>>#/";
 
     expect_args!(SIGNATURE, args, [
-        // Value::Integer(a) => a,
-        // Value::Integer(b) => b,
         a => a,
         b => b,
     ]);
@@ -243,11 +241,6 @@ fn divide_float(_: &mut Universe, args: Vec<Value>) -> Return {
         (Value::Double(a), Value::Double(b)) => Return::Local(Value::Double(a / b)),
         _ => return Return::Exception(format!("'{}': wrong types", SIGNATURE)),
     }
-
-    // let a = promote!(SIGNATURE, a);
-    // let b = promote!(SIGNATURE, b);
-
-    // Return::Local(Value::Double(a / b))
 }
 
 fn modulo(_: &mut Universe, args: Vec<Value>) -> Return {
@@ -356,8 +349,8 @@ fn lt(_: &mut Universe, args: Vec<Value>) -> Return {
         (Value::Integer(a), Value::Double(b)) | (Value::Double(b), Value::Integer(a)) => {
             Return::Local(Value::Boolean((a as f64) < b))
         }
-        (Value::BigInteger(_), Value::Integer(_)) => Return::Local(Value::Boolean(false)),
-        (Value::Integer(_), Value::BigInteger(_)) => Return::Local(Value::Boolean(true)),
+        (Value::BigInteger(a), Value::Integer(b)) => Return::Local(Value::Boolean(a < BigInt::from(b))),
+        (Value::Integer(a), Value::BigInteger(b)) => Return::Local(Value::Boolean(b < BigInt::from(a))),
         (a, b) => {
             return Return::Exception(format!("'{}': wrong types ({:?} | {:?})", SIGNATURE, a, b))
         }
@@ -387,40 +380,36 @@ fn shift_left(_: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "Integer>>#<<";
 
     expect_args!(SIGNATURE, args, [
-        Value::Integer(a) => a,
+        a => a,
         Value::Integer(b) => b,
     ]);
 
-    Return::Local(Value::Integer(a << b))
-
-    // match a {
-    //     Value::Integer(a) => match a.checked_shl(b as u32) {
-    //         Some(value) => Return::Local(Value::Integer(value)),
-    //         None => demote!(BigInt::from(a) << (b as usize)),
-    //     },
-    //     Value::BigInteger(a) => demote!(a << (b as usize)),
-    //     _ => return Return::Exception(format!("'{}': wrong types", SIGNATURE)),
-    // }
+    match a {
+        Value::Integer(a) => match a.checked_shl(b as u32) {
+            Some(value) => Return::Local(Value::Integer(value)),
+            None => demote!(BigInt::from(a) << (b as usize)),
+        },
+        Value::BigInteger(a) => demote!(a << (b as usize)),
+        _ => return Return::Exception(format!("'{}': wrong types", SIGNATURE)),
+    }
 }
 
 fn shift_right(_: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "Integer>>#>>";
 
     expect_args!(SIGNATURE, args, [
-        Value::Integer(a) => a,
+        a => a,
         Value::Integer(b) => b,
     ]);
 
-    Return::Local(Value::Integer(a >> b))
-
-    // match a {
-    //     Value::Integer(a) => match a.checked_shr(b as u32) {
-    //         Some(value) => Return::Local(Value::Integer(value)),
-    //         None => demote!(BigInt::from(a) >> (b as usize)),
-    //     },
-    //     Value::BigInteger(a) => demote!(a >> (b as usize)),
-    //     _ => return Return::Exception(format!("'{}': wrong types", SIGNATURE)),
-    // }
+    match a {
+        Value::Integer(a) => match a.checked_shr(b as u32) {
+            Some(value) => Return::Local(Value::Integer(value)),
+            None => demote!(BigInt::from(a) >> (b as usize)),
+        },
+        Value::BigInteger(a) => demote!(a >> (b as usize)),
+        _ => return Return::Exception(format!("'{}': wrong types", SIGNATURE)),
+    }
 }
 
 /// Search for a primitive matching the given signature.

--- a/som-lexer/src/token.rs
+++ b/som-lexer/src/token.rs
@@ -55,6 +55,8 @@ pub enum Token {
     Separator,
     /// An integer literal (`10`).
     LitInteger(i64),
+    /// A big integer literal (`1542252643255252434`).
+    LitBigInteger(String),
     /// A floating-point literal (`10.6`).
     LitDouble(f64),
     /// A string literal (`'hello, world'`).

--- a/som-parser-symbols/src/lang.rs
+++ b/som-parser-symbols/src/lang.rs
@@ -42,6 +42,19 @@ pub fn exact_ident<'a, 'b: 'a>(string: &'b str) -> impl Parser<'a, ()> {
     }
 }
 
+pub fn big_integer<'a>() -> impl Parser<'a, String> {
+    move |input: &'a [Token]| {
+        let (sign, input) = optional(exact(Token::Minus)).parse(input)?;
+        let sign = if sign.is_some() { "-" } else { "" };
+
+        let (head, tail) = input.split_first()?;
+        match head {
+            Token::LitBigInteger(value) => Some((format!("{}{}", sign, value), tail)),
+            _ => None,
+        }
+    }
+}
+
 pub fn integer<'a>() -> impl Parser<'a, i64> {
     move |input: &'a [Token]| {
         let (sign, input) = optional(exact(Token::Minus)).parse(input)?;
@@ -149,6 +162,7 @@ pub fn array<'a>() -> impl Parser<'a, Vec<Literal>> {
 pub fn literal<'a>() -> impl Parser<'a, Literal> {
     (double().map(Literal::Double))
         .or(integer().map(Literal::Integer))
+        .or(big_integer().map(Literal::BigInteger))
         .or(string().map(Literal::String))
         .or(symbol().map(Literal::Symbol))
         .or(array().map(Literal::Array))


### PR DESCRIPTION
This PR aims to add support for arbitrarily big integers to `som-interpreter`.  
The support for big integers would be backed by the `BigInt` type from the `num-bigint` crate.  
These take the form of a new variant in the `Value` enum (called `BigInteger`).  
The SOM class associated to such values stays `Integer`, and whether an integer value is stored as `Value::Integer` or `Value::BigInteger` should be abstracted away from SOM programs.  

Any operation on `Value::Integer` that would make it overflow should trigger an automatic promotion to `Value::BigInteger`.  

Some questions remaining unclear:
- Should `Value::BigInteger` ever be downgraded to `Value::Integer` when possible ?
  - And where should that happen ?
- What's the interaction with the already implemented `Value::Integer` to `Value::Double` automatic promotion mechanisms ?
  - Should we implement a `Value::BigDecimal` to allow promoting `Value::BigInteger` to an instance of `Double` ?