### PR TITLE
Support for message cascades

### DIFF
--- a/som-core/src/ast.rs
+++ b/som-core/src/ast.rs
@@ -141,6 +141,8 @@ pub enum Expression {
     Block(Block),
     /// A term (eg. `( counter increment )`).
     Term(Term),
+    /// A cascade (eg. `self increment; increment; increment`)
+    Cascade(Cascade),
 }
 
 /// Represents a message send.
@@ -216,6 +218,30 @@ pub struct Block {
 pub struct Term {
     /// The body of the term.
     pub body: Body,
+}
+
+/// Represents a cascade.
+///
+/// Exemple:
+/// ```text
+/// "simple cascade"
+/// Point new setX: 25 setY: 35; isZero
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct Cascade {
+    pub receiver: Box<Expression>,
+    pub sequences: Vec<CascadeMessageSequence>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CascadeMessage {
+    pub signature: String,
+    pub values: Vec<Expression>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CascadeMessageSequence {
+    pub messages: Vec<CascadeMessage>,
 }
 
 /// Represents a literal.

--- a/som-lexer/src/lexer.rs
+++ b/som-lexer/src/lexer.rs
@@ -232,6 +232,10 @@ impl Iterator for Lexer {
                     Some(Token::Colon)
                 }
             }
+            ';' => {
+                self.chars.pop()?;
+                Some(Token::Semicolon)
+            }
             _ if Lexer::is_operator(peeked) => self.lex_operator(),
             _ => {
                 let primitive_len = Lexer::PRIMITIVE.chars().count();

--- a/som-lexer/src/token.rs
+++ b/som-lexer/src/token.rs
@@ -35,6 +35,8 @@ pub enum Token {
     EndBlock,
     /// A colon (`:`).
     Colon,
+    /// A semicolon (`;`).
+    Semicolon,
     /// A period, the statement terminator (`.`).
     Period,
     /// A caret, the return operator (`^`).


### PR DESCRIPTION
This PR adds support for Smalltalk's syntax for message cascades.  

This syntax allows to send multiple sequences of messages to the same object without resorting to a temporary intermediate field.

Message cascades are not part of the base SOM language and are not implemented by any other SOM interpreters (as far as I know), but it is a fun syntax that is added here as an extension.  

Here is an example of it, running in the `som-rs` shell:
```plain
(0) SOM Shell | Vector new append: #foo; size println; append: 'bar'; size println; append: #(4 5 6); size println; value
1
2
3
returned: instance of Vector class (Instance(Instance { name: "Vector", locals: ["last", "storage", "first"] }))
(1) SOM Shell | it asArray
returned: #(#foo bar #(4 5 6)) (Array([Symbol(Interned(1)), String("bar"), Array([Integer(4), Integer(5), Integer(6)])]))
```

Here is another example, showing that binary messages can also be used in a cascade:
```plain
(0) SOM Shell | 1; , 2
returned: instance of Vector class (Instance(Instance { name: "Vector", locals: ["first", "last", "storage"] }))
(1) SOM Shell | it size
returned: 2 (Integer(2))
(2) SOM Shell | 1; + 2
returned: 3 (Integer(3))
```