### PR TITLE
Prototype for span-based ASTs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,9 @@ dependencies = [
 [[package]]
 name = "som-lexer"
 version = "0.1.0"
+dependencies = [
+ "som-core 0.1.0",
+]
 
 [[package]]
 name = "som-parser-symbols"

--- a/som-core/src/lib.rs
+++ b/som-core/src/lib.rs
@@ -6,3 +6,5 @@
 pub mod ast;
 /// The SOM bytecode definitions.
 pub mod bytecode;
+/// Span information.
+pub mod span;

--- a/som-core/src/span.rs
+++ b/som-core/src/span.rs
@@ -1,0 +1,26 @@
+/// Represents a region of source code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Span {
+    pub from: usize,
+    pub to: usize,
+}
+
+impl Span {
+    /// Construct a span given its lower and upper bounds.
+    pub fn new(from: usize, to: usize) -> Self {
+        Self { from, to }
+    }
+
+    /// Construct the span going from the beginning of the first span to the end of the second span.
+    pub fn between(s1: Self, s2: Self) -> Self {
+        Self {
+            from: s1.from,
+            to: s2.to,
+        }
+    }
+
+    /// Get the string slice corresponding to this span.
+    pub fn to_str(self, source: &str) -> &str {
+        &source[self.from..self.to]
+    }
+}

--- a/som-interpreter/src/frame.rs
+++ b/som-interpreter/src/frame.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use crate::block::Block;
 use crate::class::Class;
+use crate::interner::Interned;
 use crate::value::Value;
 use crate::SOMRef;
 
@@ -29,7 +30,7 @@ pub struct Frame {
     /// This frame's kind.
     pub kind: FrameKind,
     /// The bindings within this frame.
-    pub bindings: HashMap<String, Value>,
+    pub bindings: HashMap<Interned, Value>,
 }
 
 impl Frame {
@@ -63,9 +64,8 @@ impl Frame {
     }
 
     /// Search for a local binding.
-    pub fn lookup_local(&self, name: impl AsRef<str>) -> Option<Value> {
-        let name = name.as_ref();
-        if let Some(value) = self.bindings.get(name).cloned() {
+    pub fn lookup_local(&self, name: Interned) -> Option<Value> {
+        if let Some(value) = self.bindings.get(&name).cloned() {
             return Some(value);
         }
         match &self.kind {
@@ -81,9 +81,8 @@ impl Frame {
     }
 
     /// Assign to a local binding.
-    pub fn assign_local(&mut self, name: impl AsRef<str>, value: Value) -> Option<()> {
-        let name = name.as_ref();
-        if let Some(local) = self.bindings.get_mut(name) {
+    pub fn assign_local(&mut self, name: Interned, value: Value) -> Option<()> {
+        if let Some(local) = self.bindings.get_mut(&name) {
             *local = value;
             return Some(());
         }

--- a/som-interpreter/src/instance.rs
+++ b/som-interpreter/src/instance.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 use crate::class::Class;
+use crate::interner::Interned;
 use crate::value::Value;
 use crate::SOMRef;
 
@@ -11,7 +12,7 @@ pub struct Instance {
     /// The class of which this is an instance from.
     pub class: SOMRef<Class>,
     /// This instance's locals.
-    pub locals: HashMap<String, Value>,
+    pub locals: HashMap<Interned, Value>,
 }
 
 impl Instance {
@@ -19,7 +20,7 @@ impl Instance {
     pub fn from_class(class: SOMRef<Class>) -> Self {
         let mut locals = HashMap::new();
 
-        fn collect_locals(class: &SOMRef<Class>, locals: &mut HashMap<String, Value>) {
+        fn collect_locals(class: &SOMRef<Class>, locals: &mut HashMap<Interned, Value>) {
             if let Some(class) = class.borrow().super_class() {
                 collect_locals(&class, locals);
             }
@@ -28,7 +29,7 @@ impl Instance {
                     .borrow()
                     .locals
                     .keys()
-                    .cloned()
+                    .copied()
                     .zip(std::iter::repeat(Value::Nil)),
             );
         }
@@ -49,13 +50,13 @@ impl Instance {
     }
 
     /// Search for a local binding.
-    pub fn lookup_local(&self, name: impl AsRef<str>) -> Option<Value> {
-        self.locals.get(name.as_ref()).cloned()
+    pub fn lookup_local(&self, name: Interned) -> Option<Value> {
+        self.locals.get(&name).cloned()
     }
 
     /// Assign a value to a local binding.
-    pub fn assign_local(&mut self, name: impl AsRef<str>, value: Value) -> Option<()> {
-        *self.locals.get_mut(name.as_ref())? = value;
+    pub fn assign_local(&mut self, name: Interned, value: Value) -> Option<()> {
+        *self.locals.get_mut(&name)? = value;
         Some(())
     }
 }

--- a/som-interpreter/src/method.rs
+++ b/som-interpreter/src/method.rs
@@ -6,6 +6,8 @@ use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::{SOMRef, SOMWeakRef};
 
+use crate::interner::Interned;
+
 /// The kind of a class method.
 #[derive(Clone)]
 pub enum MethodKind {
@@ -65,7 +67,7 @@ impl MethodKind {
 pub struct Method {
     pub kind: MethodKind,
     pub holder: SOMWeakRef<Class>,
-    pub signature: String,
+    pub signature: Interned,
 }
 
 impl Method {
@@ -85,8 +87,8 @@ impl Method {
         &self.holder
     }
 
-    pub fn signature(&self) -> &str {
-        self.signature.as_str()
+    pub fn signature(&self) -> Interned {
+        self.signature
     }
 
     /// Whether this invocable is a primitive.

--- a/som-interpreter/src/primitives/class.rs
+++ b/som-interpreter/src/primitives/class.rs
@@ -73,13 +73,7 @@ fn fields(universe: &mut Universe, args: Vec<Value>) -> Return {
             Some(super_class) => gather_locals(universe, super_class),
             None => Vec::new(),
         };
-        fields.extend(
-            class
-                .borrow()
-                .locals
-                .keys()
-                .map(|field| Value::Symbol(universe.intern_symbol(field))),
-        );
+        fields.extend(class.borrow().locals.keys().copied().map(Value::Symbol));
         fields
     }
 

--- a/som-interpreter/src/primitives/method.rs
+++ b/som-interpreter/src/primitives/method.rs
@@ -20,15 +20,14 @@ fn holder(_: &mut Universe, args: Vec<Value>) -> Return {
     }
 }
 
-fn signature(universe: &mut Universe, args: Vec<Value>) -> Return {
+fn signature(_: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "Method>>#signature";
 
     expect_args!(SIGNATURE, args, [
         Value::Invokable(invokable) => invokable,
     ]);
 
-    let sym = universe.intern_symbol(invokable.signature());
-    Return::Local(Value::Symbol(sym))
+    Return::Local(Value::Symbol(invokable.signature()))
 }
 
 fn invoke_on_with(universe: &mut Universe, args: Vec<Value>) -> Return {

--- a/som-interpreter/src/primitives/system.rs
+++ b/som-interpreter/src/primitives/system.rs
@@ -70,8 +70,7 @@ fn global(universe: &mut Universe, args: Vec<Value>) -> Return {
         Value::Symbol(sym) => sym,
     ]);
 
-    let symbol = universe.lookup_symbol(sym);
-    Return::Local(universe.lookup_global(symbol).unwrap_or(Value::Nil))
+    Return::Local(universe.lookup_global(sym).unwrap_or(Value::Nil))
 }
 
 fn global_put(universe: &mut Universe, args: Vec<Value>) -> Return {
@@ -83,8 +82,7 @@ fn global_put(universe: &mut Universe, args: Vec<Value>) -> Return {
         value => value,
     ]);
 
-    let symbol = universe.lookup_symbol(sym).to_string();
-    universe.assign_global(symbol, value.clone());
+    universe.assign_global(sym, value.clone());
     Return::Local(value)
 }
 

--- a/som-interpreter/src/shell.rs
+++ b/som-interpreter/src/shell.rs
@@ -1,5 +1,7 @@
+use std::cell::RefCell;
 use std::io;
 use std::io::{BufRead, Write};
+use std::rc::Rc;
 use std::time::Instant;
 
 use anyhow::Error;
@@ -8,9 +10,9 @@ use som_lexer::{Lexer, Token};
 use som_parser::lang;
 use som_parser::Parser;
 
-use som_interpreter::evaluate::Evaluate;
 use som_interpreter::frame::FrameKind;
-use som_interpreter::invokable::Return;
+use som_interpreter::instance::Instance;
+use som_interpreter::invokable::{Invoke, Return};
 use som_interpreter::universe::Universe;
 use som_interpreter::value::Value;
 
@@ -20,6 +22,9 @@ pub fn interactive(universe: &mut Universe, verbose: bool) -> Result<(), Error> 
     let mut stdin = stdin.lock();
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
+
+    let it_sym = universe.intern_symbol("it");
+    let eval_sym = universe.intern_symbol("eval:");
 
     let mut counter = 0;
     let mut line = String::new();
@@ -41,8 +46,10 @@ pub fn interactive(universe: &mut Universe, verbose: bool) -> Result<(), Error> 
             break;
         }
 
+        let class = format!("ShellExpr{} = ( eval: it = ( ^ ( {} ) ) )", counter, line);
+
         let start = Instant::now();
-        let tokens: Vec<Token> = Lexer::new(line)
+        let tokens: Vec<Token> = Lexer::new(class.as_str())
             .skip_comments(true)
             .skip_whitespace(true)
             .collect();
@@ -57,9 +64,9 @@ pub fn interactive(universe: &mut Universe, verbose: bool) -> Result<(), Error> 
         }
 
         let start = Instant::now();
-        let expr = match lang::expression().parse(tokens.as_slice()) {
-            Some((expr, rest)) if rest.is_empty() => expr,
-            Some(_) | None => {
+        let expr = match som_parser::parse_file(class.as_str(), tokens.as_slice()) {
+            Some(expr) => expr,
+            None => {
                 println!("ERROR: could not fully parse the given expression");
                 continue;
             }
@@ -74,48 +81,56 @@ pub fn interactive(universe: &mut Universe, verbose: bool) -> Result<(), Error> 
             )?;
         }
 
-        let start = Instant::now();
-        let kind = FrameKind::Method {
-            holder: universe.system_class(),
-            self_value: Value::System,
-        };
-        let output = universe.with_frame(kind, |universe| {
-            universe
-                .current_frame()
-                .borrow_mut()
-                .bindings
-                .insert("it".into(), last_value.clone());
+        let class = universe.load_class_from_memory(class)?;
+        let instance = Instance::from_class(class.clone());
 
-            expr.evaluate(universe)
-        });
-        let elapsed = start.elapsed();
-        if verbose {
-            writeln!(
-                &mut stdout,
-                "Execution time: {} ms ({} µs)",
-                elapsed.as_millis(),
-                elapsed.as_micros(),
-            )?;
-            writeln!(&mut stdout)?;
+        let method = class.borrow().lookup_method(eval_sym);
+        if let Some(method) = method {
+            let start = Instant::now();
+            let kind = FrameKind::Method {
+                holder: universe.system_class(),
+                self_value: Value::System,
+            };
+
+            let output = method.invoke(
+                universe,
+                vec![Value::Instance(Rc::new(RefCell::new(instance))), last_value.clone()],
+            );
+            let elapsed = start.elapsed();
+            if verbose {
+                writeln!(
+                    &mut stdout,
+                    "Execution time: {} ms ({} µs)",
+                    elapsed.as_millis(),
+                    elapsed.as_micros(),
+                )?;
+                writeln!(&mut stdout)?;
+            }
+            match output {
+                Return::Local(value) => {
+                    println!(
+                        "returned: {} ({})",
+                        value.as_display(universe),
+                        value.as_debug(universe),
+                    );
+                    last_value = value;
+                }
+                Return::NonLocal(value, frame) => {
+                    println!(
+                        "returned (non-local, escaped): {} ({})",
+                        value.as_display(universe),
+                        value.as_debug(universe),
+                    );
+                    println!("intended for frame: {:?}", frame);
+                    last_value = value;
+                }
+                Return::Exception(message) => println!("ERROR: {}", message),
+                Return::Restart => println!("ERROR: asked for a restart to the top-level"),
+            }
+        } else {
+            panic!("SOM shell's `eval` method not found ??");
         }
 
-        match output {
-            Return::Local(value) => {
-                println!("returned: {} ({:?})", value.to_string(&universe), value);
-                last_value = value;
-            }
-            Return::NonLocal(value, frame) => {
-                println!(
-                    "returned (non-local, escaped): {} ({:?})",
-                    value.to_string(&universe),
-                    value
-                );
-                println!("intended for frame: {:?}", frame);
-                last_value = value;
-            }
-            Return::Exception(message) => println!("ERROR: {}", message),
-            Return::Restart => println!("ERROR: asked for a restart to the top-level"),
-        }
         counter += 1;
     }
 

--- a/som-lexer/Cargo.toml
+++ b/som-lexer/Cargo.toml
@@ -8,3 +8,5 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+# internal
+som-core = { path = "../som-core", version = "0.1.0" }

--- a/som-lexer/src/lib.rs
+++ b/som-lexer/src/lib.rs
@@ -9,4 +9,4 @@ mod lexer;
 mod token;
 
 pub use crate::lexer::Lexer;
-pub use crate::token::Token;
+pub use crate::token::{Token, TokenKind};

--- a/som-lexer/src/token.rs
+++ b/som-lexer/src/token.rs
@@ -1,6 +1,8 @@
-/// Represents a token from the lexer.
-#[derive(Debug, Clone, PartialEq)]
-pub enum Token {
+use som_core::span::Span;
+
+/// Represents the kind of a token from the lexer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TokenKind {
     /// A tilde, the bitwise 'not' operator (`~`).
     Not,
     /// A ampersand, the binary 'and' operator (`&`).
@@ -54,21 +56,47 @@ pub enum Token {
     /// The separator sequence (`-------`).
     Separator,
     /// An integer literal (`10`).
-    LitInteger(i64),
+    LitInteger,
     /// A floating-point literal (`10.6`).
-    LitDouble(f64),
+    LitDouble,
     /// A string literal (`'hello, world'`).
-    LitString(String),
+    LitString(Span),
     /// A symbol literal (`#foo`).
-    LitSymbol(String),
+    LitSymbol(Span),
     /// An identifier (`foo`).
-    Identifier(String),
+    Identifier,
     /// A keyword (`fromString:`).
-    Keyword(String),
+    Keyword,
     /// A sequence of operators (eg: `>>>`).
-    OperatorSequence(String),
+    OperatorSequence,
     /// A comment (`"what a beautiful and majestic piece of code"`).
-    Comment(String),
+    Comment(Span),
     /// Some whitespace (` `).
     Whitespace,
+}
+
+/// Represents a token from the lexer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Token {
+    /// The span of the token.
+    span: Span,
+    /// The kind of the token.
+    kind: TokenKind,
+}
+
+impl Token {
+    /// Construct a token given its span and its kind.
+    pub fn new(span: Span, kind: TokenKind) -> Self {
+        Self { span, kind }
+    }
+
+    /// Get the kind of the token.
+    pub fn kind(&self) -> TokenKind {
+        self.kind
+    }
+
+    /// Get the span of the token.
+    pub fn span(&self) -> Span {
+        self.span
+    }
 }

--- a/som-lexer/tests/tests.rs
+++ b/som-lexer/tests/tests.rs
@@ -1,49 +1,58 @@
-use som_lexer::{Lexer, Token};
+use som_core::span::Span;
+use som_lexer::{Lexer, TokenKind};
 
 #[test]
 fn empty_class_test() {
-    let mut lexer = Lexer::new("Foo = ()");
+    const CODE: &str = "Foo = ()";
 
-    assert_eq!(lexer.next(), Some(Token::Identifier(String::from("Foo"))));
-    assert_eq!(lexer.next(), Some(Token::Whitespace));
-    assert_eq!(lexer.next(), Some(Token::Equal));
-    assert_eq!(lexer.next(), Some(Token::Whitespace));
-    assert_eq!(lexer.next(), Some(Token::NewTerm));
-    assert_eq!(lexer.next(), Some(Token::EndTerm));
+    let mut lexer = Lexer::new(CODE).map(|token| (token.span().to_str(CODE), token.kind()));
+
+    assert_eq!(lexer.next(), Some(("Foo", TokenKind::Identifier)));
+    assert_eq!(lexer.next(), Some((" ", TokenKind::Whitespace)));
+    assert_eq!(lexer.next(), Some(("=", TokenKind::Equal)));
+    assert_eq!(lexer.next(), Some((" ", TokenKind::Whitespace)));
+    assert_eq!(lexer.next(), Some(("(", TokenKind::NewTerm)));
+    assert_eq!(lexer.next(), Some((")", TokenKind::EndTerm)));
     assert_eq!(lexer.next(), None);
 }
 
 #[test]
 fn symbol_literal_test() {
-    let mut lexer = Lexer::new("#key:word:");
+    const CODE: &str = "#key:word:";
+
+    let mut lexer = Lexer::new(CODE).map(|token| (token.span().to_str(CODE), token.kind()));
 
     assert_eq!(
         lexer.next(),
-        Some(Token::LitSymbol(String::from("key:word:")))
+        Some(("#key:word:", TokenKind::LitSymbol(Span::new(1, 10))))
     );
     assert_eq!(lexer.next(), None);
 }
 
 #[test]
 fn assignment_test() {
-    let mut lexer = Lexer::new("var := 3.14.");
+    const CODE: &str = "var := 3.14.";
 
-    assert_eq!(lexer.next(), Some(Token::Identifier(String::from("var"))));
-    assert_eq!(lexer.next(), Some(Token::Whitespace));
-    assert_eq!(lexer.next(), Some(Token::Assign));
-    assert_eq!(lexer.next(), Some(Token::Whitespace));
-    assert_eq!(lexer.next(), Some(Token::LitDouble(3.14)));
-    assert_eq!(lexer.next(), Some(Token::Period));
+    let mut lexer = Lexer::new(CODE).map(|token| (token.span().to_str(CODE), token.kind()));
+
+    assert_eq!(lexer.next(), Some(("var", TokenKind::Identifier)));
+    assert_eq!(lexer.next(), Some((" ", TokenKind::Whitespace)));
+    assert_eq!(lexer.next(), Some((":=", TokenKind::Assign)));
+    assert_eq!(lexer.next(), Some((" ", TokenKind::Whitespace)));
+    assert_eq!(lexer.next(), Some(("3.14", TokenKind::LitDouble)));
+    assert_eq!(lexer.next(), Some((".", TokenKind::Period)));
     assert_eq!(lexer.next(), None);
 }
 
 #[test]
 fn string_literal_test() {
-    let mut lexer = Lexer::new("'some string with new\nline'");
+    const CODE: &str = "'some string with new\nline'";
+
+    let mut lexer = Lexer::new(CODE).map(|token| (token.span().to_str(CODE), token.kind()));
 
     assert_eq!(
         lexer.next(),
-        Some(Token::LitString(String::from("some string with new\nline")))
+        Some((CODE, TokenKind::LitString(Span::new(1, 26))))
     );
     assert_eq!(lexer.next(), None);
 }

--- a/som-parser-symbols/src/lib.rs
+++ b/som-parser-symbols/src/lib.rs
@@ -17,7 +17,7 @@ use som_core::ast::ClassDef;
 use som_lexer::Token;
 
 /// Parses the input of an entire file into an AST.
-pub fn parse_file(input: &[Token]) -> Option<ClassDef> {
-    let (class, _) = lang::file().parse(input)?;
+pub fn parse_file(source: &str, input: &[Token]) -> Option<ClassDef> {
+    let (class, _) = lang::file(source).parse(input)?;
     Some(class)
 }

--- a/som-parser-symbols/tests/tests.rs
+++ b/som-parser-symbols/tests/tests.rs
@@ -1,4 +1,5 @@
 use som_core::ast::*;
+use som_core::span::Span;
 use som_lexer::{Lexer, Token};
 use som_parser_symbols::combinators::*;
 use som_parser_symbols::lang::*;
@@ -6,9 +7,9 @@ use som_parser_symbols::Parser;
 
 #[test]
 fn literal_tests() {
-    let tokens: Vec<Token> = Lexer::new("1.2 5 #foo 'test'")
-        .skip_whitespace(true)
-        .collect();
+    const CODE: &str = "1.2 5 #foo 'test'";
+
+    let tokens: Vec<Token> = Lexer::new(CODE).skip_whitespace(true).collect();
 
     let parser = many(literal());
     let result = parser.parse(tokens.as_slice());
@@ -18,20 +19,44 @@ fn literal_tests() {
     assert!(rest.is_empty(), "input did not parse in its entirety");
 
     let mut iter = literals.into_iter();
-    assert_eq!(iter.next(), Some(Literal::Double(1.2)));
-    assert_eq!(iter.next(), Some(Literal::Integer(5)));
-    assert_eq!(iter.next(), Some(Literal::Symbol(String::from("foo"))));
-    assert_eq!(iter.next(), Some(Literal::String(String::from("test"))));
+    assert_eq!(
+        iter.next(),
+        Some(Expression {
+            span: Span::new(0, 3),
+            kind: ExpressionKind::Literal(Literal::Double),
+        })
+    );
+    assert_eq!(
+        iter.next(),
+        Some(Expression {
+            span: Span::new(4, 5),
+            kind: ExpressionKind::Literal(Literal::Integer),
+        })
+    );
+    assert_eq!(
+        iter.next(),
+        Some(Expression {
+            span: Span::new(6, 10),
+            kind: ExpressionKind::Literal(Literal::Symbol(Span::new(7, 10))),
+        })
+    );
+    assert_eq!(
+        iter.next(),
+        Some(Expression {
+            span: Span::new(11, 17),
+            kind: ExpressionKind::Literal(Literal::String(Span::new(12, 16))),
+        })
+    );
     assert_eq!(iter.next(), None);
 }
 
 #[test]
 fn expression_test_1() {
-    let tokens: Vec<Token> = Lexer::new("3 + counter get")
-        .skip_whitespace(true)
-        .collect();
+    const CODE: &str = "3 + counter get";
 
-    let parser = expression();
+    let tokens: Vec<Token> = Lexer::new(CODE).skip_whitespace(true).collect();
+
+    let parser = expression(CODE);
     let result = parser.parse(tokens.as_slice());
 
     assert!(result.is_some(), "input did not parse successfully");
@@ -40,26 +65,39 @@ fn expression_test_1() {
 
     assert_eq!(
         expression,
-        Expression::BinaryOp(BinaryOp {
-            op: String::from("+"),
-            lhs: Box::new(Expression::Literal(Literal::Integer(3))),
-            rhs: Box::new(Expression::Message(Message {
-                receiver: Box::new(Expression::Reference(String::from("counter"))),
-                signature: String::from("get"),
-                values: vec![],
-            }))
-        })
+        Expression {
+            span: Span::new(0, 15),
+            kind: ExpressionKind::Message(Message {
+                signature: String::from("+"),
+                receiver: Box::new(Expression {
+                    span: Span::new(0, 1),
+                    kind: ExpressionKind::Literal(Literal::Integer)
+                }),
+                kind: MessageKind::Binary {
+                    rhs: Box::new(Expression {
+                        span: Span::new(4, 15),
+                        kind: ExpressionKind::Message(Message {
+                            signature: String::from("get"),
+                            receiver: Box::new(Expression {
+                                span: Span::new(4, 11),
+                                kind: ExpressionKind::Reference,
+                            }),
+                            kind: MessageKind::Unary,
+                        })
+                    })
+                }
+            })
+        }
     );
 }
 
 #[test]
 fn block_test() {
-    let tokens: Vec<Token> =
-        Lexer::new("[ :test | |local| local := 'this is correct'. local println. ]")
-            .skip_whitespace(true)
-            .collect();
+    const CODE: &str = "[ :test | |local| local := 'this is correct'. local println. ]";
 
-    let parser = block();
+    let tokens: Vec<Token> = Lexer::new(CODE).skip_whitespace(true).collect();
+
+    let parser = block(CODE);
     let result = parser.parse(tokens.as_slice());
 
     assert!(result.is_some(), "input did not parse successfully");
@@ -68,38 +106,52 @@ fn block_test() {
 
     assert_eq!(
         block,
-        Expression::Block(Block {
-            parameters: vec![String::from("test")],
-            locals: vec![String::from("local")],
-            body: Body {
-                exprs: vec![
-                    Expression::Assignment(
-                        String::from("local"),
-                        Box::new(Expression::Literal(Literal::String(String::from(
-                            "this is correct"
-                        ))))
-                    ),
-                    Expression::Message(Message {
-                        receiver: Box::new(Expression::Reference(String::from("local"))),
-                        signature: String::from("println"),
-                        values: vec![],
-                    })
-                ],
-                full_stopped: true,
-            }
-        }),
+        Expression {
+            span: Span::new(0, 62),
+            kind: ExpressionKind::Block(Block {
+                parameters: vec![Span::new(3, 7)],
+                locals: vec![Span::new(11, 16)],
+                body: Body {
+                    exprs: vec![
+                        Expression {
+                            span: Span::new(18, 44),
+                            kind: ExpressionKind::Assignment(
+                                Span::new(18, 23),
+                                Box::new(Expression {
+                                    span: Span::new(27, 44),
+                                    kind: ExpressionKind::Literal(Literal::String(Span::new(
+                                        28, 43
+                                    )))
+                                }),
+                            )
+                        },
+                        Expression {
+                            span: Span::new(46, 59),
+                            kind: ExpressionKind::Message(Message {
+                                receiver: Box::new(Expression {
+                                    span: Span::new(46, 51),
+                                    kind: ExpressionKind::Reference
+                                }),
+                                signature: String::from("println"),
+                                kind: MessageKind::Unary,
+                            })
+                        }
+                    ],
+                    full_stopped: true,
+                }
+            })
+        },
     );
 }
 
 #[test]
 fn expression_test_2() {
-    let tokens: Vec<Token> = Lexer::new(
-        "( 3 == 3 ) ifTrue: [ 'this is correct' println. ] ifFalse: [ 'oh no' println ]",
-    )
-    .skip_whitespace(true)
-    .collect();
+    const CODE: &str =
+        "( 3 == 3 ) ifTrue: [ 'this is correct' println. ] ifFalse: [ 'oh no' println ]";
 
-    let parser = expression();
+    let tokens: Vec<Token> = Lexer::new(CODE).skip_whitespace(true).collect();
+
+    let parser = expression(CODE);
     let result = parser.parse(tokens.as_slice());
 
     assert!(result.is_some(), "input did not parse successfully");
@@ -108,112 +160,86 @@ fn expression_test_2() {
 
     assert_eq!(
         expression,
-        Expression::Message(Message {
-            receiver: Box::new(Expression::Term(Term {
-                body: Body {
-                    exprs: vec![Expression::BinaryOp(BinaryOp {
-                        op: String::from("=="),
-                        lhs: Box::new(Expression::Literal(Literal::Integer(3))),
-                        rhs: Box::new(Expression::Literal(Literal::Integer(3))),
-                    })],
-                    full_stopped: false,
+        Expression {
+            span: Span::new(0, 78),
+            kind: ExpressionKind::Message(Message {
+                receiver: Box::new(Expression {
+                    span: Span::new(0, 10),
+                    kind: ExpressionKind::Term(Term {
+                        body: Body {
+                            exprs: vec![Expression {
+                                span: Span::new(2, 8),
+                                kind: ExpressionKind::Message(Message {
+                                    receiver: Box::new(Expression {
+                                        span: Span::new(2, 3),
+                                        kind: ExpressionKind::Literal(Literal::Integer)
+                                    }),
+                                    signature: String::from("=="),
+                                    kind: MessageKind::Binary {
+                                        rhs: Box::new(Expression {
+                                            span: Span::new(7, 8),
+                                            kind: ExpressionKind::Literal(Literal::Integer)
+                                        }),
+                                    },
+                                })
+                            }],
+                            full_stopped: false,
+                        }
+                    })
+                }),
+                signature: String::from("ifTrue:ifFalse:"),
+                kind: MessageKind::Positional {
+                    keywords: vec![Span::new(11, 18), Span::new(50, 58),],
+                    values: vec![
+                        Expression {
+                            span: Span::new(19, 49),
+                            kind: ExpressionKind::Block(Block {
+                                parameters: vec![],
+                                locals: vec![],
+                                body: Body {
+                                    exprs: vec![Expression {
+                                        span: Span::new(21, 46),
+                                        kind: ExpressionKind::Message(Message {
+                                            receiver: Box::new(Expression {
+                                                span: Span::new(21, 38),
+                                                kind: ExpressionKind::Literal(Literal::String(
+                                                    Span::new(22, 37)
+                                                ))
+                                            }),
+                                            signature: String::from("println"),
+                                            kind: MessageKind::Unary,
+                                        })
+                                    }],
+                                    full_stopped: true,
+                                }
+                            })
+                        },
+                        Expression {
+                            span: Span::new(59, 78),
+                            kind: ExpressionKind::Block(Block {
+                                parameters: vec![],
+                                locals: vec![],
+                                body: Body {
+                                    exprs: vec![Expression {
+                                        span: Span::new(61, 76),
+                                        kind: ExpressionKind::Message(Message {
+                                            receiver: Box::new(Expression {
+                                                span: Span::new(61, 68),
+                                                kind: ExpressionKind::Literal(Literal::String(
+                                                    Span::new(62, 67),
+                                                ))
+                                            }),
+                                            signature: String::from("println"),
+                                            kind: MessageKind::Unary,
+                                        })
+                                    }],
+                                    full_stopped: false,
+                                }
+                            }),
+                        }
+                    ],
                 }
-            })),
-            signature: String::from("ifTrue:ifFalse:"),
-            values: vec![
-                Expression::Block(Block {
-                    parameters: vec![],
-                    locals: vec![],
-                    body: Body {
-                        exprs: vec![Expression::Message(Message {
-                            receiver: Box::new(Expression::Literal(Literal::String(String::from(
-                                "this is correct"
-                            )))),
-                            signature: String::from("println"),
-                            values: vec![],
-                        })],
-                        full_stopped: true,
-                    }
-                }),
-                Expression::Block(Block {
-                    parameters: vec![],
-                    locals: vec![],
-                    body: Body {
-                        exprs: vec![Expression::Message(Message {
-                            receiver: Box::new(Expression::Literal(Literal::String(String::from(
-                                "oh no"
-                            )))),
-                            signature: String::from("println"),
-                            values: vec![],
-                        })],
-                        full_stopped: false,
-                    }
-                }),
-            ],
-        }),
-    );
-}
-
-#[test]
-fn primary_test() {
-    let tokens: Vec<Token> = Lexer::new("[ self fib: (n - 1) + (self fib: (n - 2)) ]")
-        .skip_whitespace(true)
-        .collect();
-    let parser = primary();
-    let result = parser.parse(tokens.as_slice());
-
-    assert!(result.is_some(), "input did not parse successfully");
-    let (primary, rest) = result.unwrap();
-    assert!(rest.is_empty(), "input did not parse in its entirety");
-
-    assert_eq!(
-        primary,
-        Expression::Block(Block {
-            parameters: vec![],
-            locals: vec![],
-            body: Body {
-                exprs: vec![Expression::Message(Message {
-                    receiver: Box::new(Expression::Reference(String::from("self"))),
-                    signature: String::from("fib:"),
-                    values: vec![Expression::BinaryOp(BinaryOp {
-                        op: String::from("+"),
-                        lhs: Box::new(Expression::Term(Term {
-                            body: Body {
-                                exprs: vec![Expression::BinaryOp(BinaryOp {
-                                    op: String::from("-"),
-                                    lhs: Box::new(Expression::Reference(String::from("n"))),
-                                    rhs: Box::new(Expression::Literal(Literal::Integer(1))),
-                                })],
-                                full_stopped: false,
-                            }
-                        })),
-                        rhs: Box::new(Expression::Term(Term {
-                            body: Body {
-                                exprs: vec![Expression::Message(Message {
-                                    receiver: Box::new(Expression::Reference(String::from("self"))),
-                                    signature: String::from("fib:"),
-                                    values: vec![Expression::Term(Term {
-                                        body: Body {
-                                            exprs: vec![Expression::BinaryOp(BinaryOp {
-                                                op: String::from("-"),
-                                                lhs: Box::new(Expression::Reference(String::from(
-                                                    "n"
-                                                ))),
-                                                rhs: Box::new(Expression::Literal(
-                                                    Literal::Integer(2)
-                                                )),
-                                            })],
-                                            full_stopped: false,
-                                        }
-                                    })],
-                                })],
-                                full_stopped: false,
-                            }
-                        }))
-                    })],
-                })],
-                full_stopped: false,
-            }
-        }),
+            }),
+        }
     );
 }


### PR DESCRIPTION
This PR experiments with refactoring the lexer and the parser to entirely rely on spans, instead of directly constructing values.  
This makes the construction of the AST a bit more efficient, since it reduces the number of allocations needed.  

The interpreter then takes the AST and can resolve spans to string slices (an efficient non-owning view into a string) when needed, by keeping around the source code for each class definitions.  

It opens the door for better error-reporting, allowing to show proper stack-traces to the user (although not done here yet and probably not within the scope of this PR).  
But it also means that things like integer literals need to be parsed into actual integers every time we evaluate one.  

I haven't done any measurements yet on the performance delta with the original implementation, so I cannot say if this is an actual improvement over it.

The implementation should already be feature-complete and in parity with the features of the original interpreter.