### PR TITLE
Fixed `Object>>#hashcode` implementation

### DIFF
--- a/som-interpreter/src/hashcode.rs
+++ b/som-interpreter/src/hashcode.rs
@@ -6,12 +6,8 @@ use crate::instance::Instance;
 use crate::method::Method;
 use crate::value::Value;
 
-pub trait Hashcode {
-    fn hashcode<H: Hasher>(&self, hasher: &mut H);
-}
-
-impl Hashcode for Value {
-    fn hashcode<H: Hasher>(&self, hasher: &mut H) {
+impl Hash for Value {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
         match self {
             Value::Nil => {
                 hasher.write(b"#nil#");
@@ -48,59 +44,59 @@ impl Hashcode for Value {
             Value::Array(value) => {
                 hasher.write(b"#int#");
                 for value in value.borrow().iter() {
-                    value.hashcode(hasher);
+                    value.hash(hasher);
                 }
             }
             Value::Block(value) => {
                 hasher.write(b"#blk#");
-                value.hashcode(hasher);
+                value.hash(hasher);
             }
             Value::Class(value) => {
                 hasher.write(b"#cls#");
-                value.borrow().hashcode(hasher);
+                value.borrow().hash(hasher);
             }
             Value::Instance(value) => {
                 hasher.write(b"#inst#");
-                value.borrow().hashcode(hasher);
+                value.borrow().hash(hasher);
             }
             Value::Invokable(value) => {
                 hasher.write(b"#mthd#");
-                value.hashcode(hasher);
+                value.hash(hasher);
             }
         }
     }
 }
 
-impl Hashcode for Class {
-    fn hashcode<H: Hasher>(&self, hasher: &mut H) {
+impl Hash for Class {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
         self.name.hash(hasher);
         self.locals.iter().for_each(|(key, value)| {
             key.hash(hasher);
-            value.hashcode(hasher);
+            value.hash(hasher);
         });
     }
 }
 
-impl Hashcode for Instance {
-    fn hashcode<H: Hasher>(&self, hasher: &mut H) {
-        self.class.borrow().hashcode(hasher);
+impl Hash for Instance {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.class.borrow().hash(hasher);
         self.locals.iter().for_each(|(key, value)| {
             key.hash(hasher);
-            value.hashcode(hasher);
+            value.hash(hasher);
         });
     }
 }
 
-impl Hashcode for Block {
-    fn hashcode<H: Hasher>(&self, hasher: &mut H) {
+impl Hash for Block {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
         todo!()
     }
 }
 
-impl Hashcode for Method {
-    fn hashcode<H: Hasher>(&self, hasher: &mut H) {
+impl Hash for Method {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
         if let Some(holder) = self.holder().upgrade() {
-            holder.borrow().hashcode(hasher);
+            holder.borrow().hash(hasher);
         } else {
             hasher.write(b"??");
         }

--- a/som-interpreter/src/lib.rs
+++ b/som-interpreter/src/lib.rs
@@ -13,6 +13,8 @@ pub mod class;
 pub mod evaluate;
 /// Facilities for manipulating stack frames.
 pub mod frame;
+/// Facilities for manipulating values.
+pub mod hashcode;
 /// Facilities for manipulating class instances.
 pub mod instance;
 /// Facilities for string interning.

--- a/som-interpreter/src/primitives/object.rs
+++ b/som-interpreter/src/primitives/object.rs
@@ -1,9 +1,8 @@
 use std::collections::hash_map::DefaultHasher;
 use std::convert::TryFrom;
-use std::hash::Hasher;
+use std::hash::{Hash, Hasher};
 
 use crate::class::Class;
-use crate::hashcode::Hashcode;
 use crate::invokable::{Invoke, Return};
 use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
@@ -34,7 +33,7 @@ fn hashcode(_: &mut Universe, args: Vec<Value>) -> Return {
     ]);
 
     let mut hasher = DefaultHasher::new();
-    value.hashcode(&mut hasher);
+    value.hash(&mut hasher);
     let hash = (hasher.finish() as i64).abs();
 
     Return::Local(Value::Integer(hash))

--- a/som-interpreter/src/primitives/object.rs
+++ b/som-interpreter/src/primitives/object.rs
@@ -3,6 +3,7 @@ use std::convert::TryFrom;
 use std::hash::Hasher;
 
 use crate::class::Class;
+use crate::hashcode::Hashcode;
 use crate::invokable::{Invoke, Return};
 use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
@@ -33,17 +34,10 @@ fn hashcode(_: &mut Universe, args: Vec<Value>) -> Return {
     ]);
 
     let mut hasher = DefaultHasher::new();
+    value.hashcode(&mut hasher);
+    let hash = (hasher.finish() as i64).abs();
 
-    // Should be fine, since we do not mutate anything ??
-    let raw_bytes: &[u8] = unsafe {
-        std::slice::from_raw_parts(
-            (&value as *const Value) as *const u8,
-            std::mem::size_of_val(&value),
-        )
-    };
-    hasher.write(raw_bytes);
-
-    Return::Local(Value::Integer((hasher.finish() as i64).abs()))
+    Return::Local(Value::Integer(hash))
 }
 
 fn eq(_: &mut Universe, args: Vec<Value>) -> Return {


### PR DESCRIPTION
This PR is fixing the bug described in **#4**, in which it is shown that the `Object>>#hashcode` primitive was broken.  

The bug is fixed by doing proper content-based hashing by now using the standard `Hash` trait.
