### PR TITLE
Benchmarking setup with ReBench

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,0 +1,30 @@
+name: Benchmarks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  rebench:
+    name: Run and report benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+      - name: Compile SOM interpreter
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release -p som-interpreter
+      - name: Run and report benchmarks
+        run: |
+          rebench --without-nice --experiment="CI Benchmark Run ID ${GITHUB_RUN_ID}" --branch="${GITHUB_REF}" -c rebench.conf som-rs

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -32,4 +32,5 @@ jobs:
           pip install rebench
       - name: Run and report benchmarks
         run: |
+          export PATH="${PATH}:${HOME}/.local/bin"
           rebench --without-nice --experiment="CI Benchmark Run ID ${GITHUB_RUN_ID}" --branch="${GITHUB_REF}" -c rebench.conf som-rs

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -27,7 +27,9 @@ jobs:
           args: --release -p som-interpreter
       - name: Install ReBench
         run: |
-          pip install wheel rebench
+          pip install setuptools
+          pip install wheel
+          pip install rebench
       - name: Run and report benchmarks
         run: |
           rebench --without-nice --experiment="CI Benchmark Run ID ${GITHUB_RUN_ID}" --branch="${GITHUB_REF}" -c rebench.conf som-rs

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -25,6 +25,9 @@ jobs:
         with:
           command: build
           args: --release -p som-interpreter
+      - name: Install ReBench
+        run: |
+          pip install rebench
       - name: Run and report benchmarks
         run: |
           rebench --without-nice --experiment="CI Benchmark Run ID ${GITHUB_RUN_ID}" --branch="${GITHUB_REF}" -c rebench.conf som-rs

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -27,7 +27,7 @@ jobs:
           args: --release -p som-interpreter
       - name: Install ReBench
         run: |
-          pip install rebench
+          pip install wheel rebench
       - name: Run and report benchmarks
         run: |
           rebench --without-nice --experiment="CI Benchmark Run ID ${GITHUB_RUN_ID}" --branch="${GITHUB_REF}" -c rebench.conf som-rs

--- a/rebench.conf
+++ b/rebench.conf
@@ -1,0 +1,70 @@
+# -*- mode: yaml -*-
+# Config file for ReBench
+default_experiment: som-rs
+default_data_file: 'rebench.data'
+
+reporting:
+    # Benchmark results will be reported to ReBenchDB
+    rebenchdb:
+        # this url needs to point to the API endpoint
+        db_url: https://rebench.polomack.eu/rebenchdb/results
+        repo_url: https://github.com/Hirevo/som-rs
+        record_all: true # make sure everything is recorded
+        project_name: som-rs
+
+runs:
+    max_invocation_time: 60
+
+benchmark_suites:
+    macro:
+        gauge_adapter: RebenchLog
+        command: &MACRO_CMD "-c core-lib/Smalltalk core-lib/Examples/Benchmarks core-lib/Examples/Benchmarks/Richards core-lib/Examples/Benchmarks/DeltaBlue core-lib/Examples/Benchmarks/NBody core-lib/Examples/Benchmarks/Json core-lib/Examples/Benchmarks/GraphSearch -- BenchmarkHarness %(benchmark)s %(iterations)s 0 "
+        iterations: 10
+        benchmarks:
+            - Richards:     {extra_args: 1}
+            - DeltaBlue:    {extra_args: 50}
+            - NBody:        {extra_args: 500}
+            - JsonSmall:    {extra_args: 1}
+            - GraphSearch:  {extra_args: 4}
+            - PageRank:     {extra_args: 40}
+
+    micro:
+        gauge_adapter: RebenchLog
+        command: "-c core-lib/Smalltalk core-lib/Examples/Benchmarks core-lib/Examples/Benchmarks/LanguageFeatures -- BenchmarkHarness %(benchmark)s %(iterations)s 0 "
+        iterations: 10
+        benchmarks:
+            - Fannkuch:     {extra_args: 6}
+            - Fibonacci:    {extra_args: "3"}
+            - Dispatch:     {extra_args: 2}
+            - Bounce:       {extra_args: "2"}
+            - Loop:         {extra_args: 5}
+            - Permute:      {extra_args: "3"}
+            - Queens:       {extra_args: "2"}
+            - List:         {extra_args: "2"}
+            - Recurse:      {extra_args: "3"}
+            - Storage:      {extra_args: 1}
+            - Sieve:        {extra_args: 4}
+            - BubbleSort:   {extra_args: "3"}
+            - QuickSort:    {extra_args: 1}
+            - Sum:          {extra_args: 2}
+            - Towers:       {extra_args: "2"}
+            - TreeSort:     {extra_args: "1"}
+            - IntegerLoop:  {extra_args: 2}
+            - FieldLoop:    {extra_args: 1}
+            - WhileLoop:    {extra_args: 10}
+            - Mandelbrot:   {extra_args: 30}
+
+executors:
+    som-rs:
+        path: .
+        executable: ./target/release/som-interpreter
+
+# define the benchmarks to be executed for a re-executable benchmark run
+experiments:
+    som-rs:
+        description: All benchmarks on som-rs
+        suites:
+            - micro
+            - macro
+        executions:
+            - som-rs


### PR DESCRIPTION
This PR adds configuration for using [**ReBench**](https://github.com/smarr/ReBench) to run and generate benchmark reports for this project and a GitHub Actions workflow for automatically run these benchmarks upon a push on master or on a pull request.  

The configuration seen in **`rebench.conf`** is very similar to the one used in CSOM, after [**SOM-st/CSOM#15**](https://github.com/SOM-st/CSOM/pull/15) got merged ([**direct link to their config file**](https://github.com/SOM-st/CSOM/blob/master/rebench.conf)).  

The major configuration differences to note currently are:
- the flags/options that have been adjusted for our interpreter (like using `-c` instead of `-cp` for specifying classpaths).
- the server to which benchmarks are reported, which is a separate [**ReBenchDB**](https://github.com/smarr/ReBenchDB) instance running at [**rebench.polomack.eu**](https://rebench.polomack.eu).