### PR TITLE
Fixed integer's `%` and `rem:` primitives

### DIFF
--- a/som-interpreter/src/primitives/integer.rs
+++ b/som-interpreter/src/primitives/integer.rs
@@ -253,7 +253,7 @@ fn modulo(_: &mut Universe, args: Vec<Value>) -> Return {
 
     let result = a % b;
     if result.signum() != b.signum() {
-        Return::Local(Value::Integer(result + b))
+        Return::Local(Value::Integer((result + b) % b))
     } else {
         Return::Local(Value::Integer(result))
     }
@@ -269,7 +269,7 @@ fn remainder(_: &mut Universe, args: Vec<Value>) -> Return {
 
     let result = a % b;
     if result.signum() != a.signum() {
-        Return::Local(Value::Integer(result + a))
+        Return::Local(Value::Integer((result + a) % a))
     } else {
         Return::Local(Value::Integer(result))
     }


### PR DESCRIPTION
This PR fixes the `%` and `rem:` methods of `Integer` to match the ones from other SOMs.  

This fix is taken from yksom's solution (found in [**softdevteam/yksom#157**](https://github.com/softdevteam/yksom/pull/157)).  

It should notably fix a few benchmarks that incorrectly ran previously.  