### PR TITLE
Added SOM's `BasicInterpreterTests` as integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,3 +28,21 @@ jobs:
       - name: Run test suite
         run: |
           ./target/release/som-interpreter -c core-lib/Smalltalk core-lib/TestSuite -- TestHarness
+
+  run_own_tests:
+    name: Run own tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+      - name: Run all tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/som-interpreter/tests/basic_interpreter_tests.rs
+++ b/som-interpreter/tests/basic_interpreter_tests.rs
@@ -1,0 +1,165 @@
+use std::path::PathBuf;
+
+use som_interpreter::evaluate::Evaluate;
+use som_interpreter::frame::FrameKind;
+use som_interpreter::invokable::Return;
+use som_interpreter::universe::Universe;
+use som_interpreter::value::Value;
+use som_lexer::{Lexer, Token};
+use som_parser::lang;
+use som_parser::Parser;
+
+fn setup_universe() -> Universe {
+    let classpath = vec![
+        PathBuf::from("../core-lib/Smalltalk"),
+        PathBuf::from("../core-lib/TestSuite/BasicInterpreterTests"),
+    ];
+    Universe::with_classpath(classpath).expect("could not setup test universe")
+}
+
+#[test]
+fn basic_interpreter_tests() {
+    let mut universe = setup_universe();
+
+    universe.load_class("Return").unwrap();
+    universe.load_class("CompilerSimplification").unwrap();
+
+    let tests: &[(&str, Value)] = &[
+        // {"Self", "assignSuper", 42, ProgramDefinitionError.class},
+        ("MethodCall test", Value::Integer(42)),
+        ("MethodCall test2", Value::Integer(42)),
+        ("NonLocalReturn test1", Value::Integer(42)),
+        ("NonLocalReturn test2", Value::Integer(43)),
+        ("NonLocalReturn test3", Value::Integer(3)),
+        ("NonLocalReturn test4", Value::Integer(42)),
+        ("NonLocalReturn test5", Value::Integer(22)),
+        ("Blocks testArg1", Value::Integer(42)),
+        ("Blocks testArg2", Value::Integer(77)),
+        ("Blocks testArgAndLocal", Value::Integer(8)),
+        ("Blocks testArgAndContext", Value::Integer(8)),
+        (
+            "Return testReturnSelf",
+            universe.lookup_global("Return").unwrap(),
+        ),
+        (
+            "Return testReturnSelfImplicitly",
+            universe.lookup_global("Return").unwrap(),
+        ),
+        (
+            "Return testNoReturnReturnsSelf",
+            universe.lookup_global("Return").unwrap(),
+        ),
+        (
+            "Return testBlockReturnsImplicitlyLastValue",
+            Value::Integer(4),
+        ),
+        ("IfTrueIfFalse test", Value::Integer(42)),
+        ("IfTrueIfFalse test2", Value::Integer(33)),
+        ("IfTrueIfFalse test3", Value::Integer(4)),
+        (
+            "CompilerSimplification testReturnConstantSymbol",
+            Value::Symbol(universe.intern_symbol("constant")),
+        ),
+        (
+            "CompilerSimplification testReturnConstantInt",
+            Value::Integer(42),
+        ),
+        (
+            "CompilerSimplification testReturnSelf",
+            universe.lookup_global("CompilerSimplification").unwrap(),
+        ),
+        (
+            "CompilerSimplification testReturnSelfImplicitly",
+            universe.lookup_global("CompilerSimplification").unwrap(),
+        ),
+        (
+            "CompilerSimplification testReturnArgumentN",
+            Value::Integer(55),
+        ),
+        (
+            "CompilerSimplification testReturnArgumentA",
+            Value::Integer(44),
+        ),
+        (
+            "CompilerSimplification testSetField",
+            Value::Symbol(universe.intern_symbol("foo")),
+        ),
+        ("CompilerSimplification testGetField", Value::Integer(40)),
+        ("Hash testHash", Value::Integer(444)),
+        ("Arrays testEmptyToInts", Value::Integer(3)),
+        ("Arrays testPutAllInt", Value::Integer(5)),
+        ("Arrays testPutAllNil", Value::Class(universe.nil_class())),
+        ("Arrays testPutAllBlock", Value::Integer(3)),
+        ("Arrays testNewWithAll", Value::Integer(1)),
+        ("BlockInlining testNoInlining", Value::Integer(1)),
+        ("BlockInlining testOneLevelInlining", Value::Integer(1)),
+        (
+            "BlockInlining testOneLevelInliningWithLocalShadowTrue",
+            Value::Integer(2),
+        ),
+        (
+            "BlockInlining testOneLevelInliningWithLocalShadowFalse",
+            Value::Integer(1),
+        ),
+        ("BlockInlining testBlockNestedInIfTrue", Value::Integer(2)),
+        ("BlockInlining testBlockNestedInIfFalse", Value::Integer(42)),
+        (
+            "BlockInlining testDeepNestedInlinedIfTrue",
+            Value::Integer(3),
+        ),
+        (
+            "BlockInlining testDeepNestedInlinedIfFalse",
+            Value::Integer(42),
+        ),
+        (
+            "BlockInlining testDeepNestedBlocksInInlinedIfTrue",
+            Value::Integer(5),
+        ),
+        (
+            "BlockInlining testDeepNestedBlocksInInlinedIfFalse",
+            Value::Integer(43),
+        ),
+        ("BlockInlining testDeepDeepNestedTrue", Value::Integer(9)),
+        ("BlockInlining testDeepDeepNestedFalse", Value::Integer(43)),
+        ("BlockInlining testToDoNestDoNestIfTrue", Value::Integer(2)),
+        ("NonLocalVars testWriteDifferentTypes", Value::Double(3.75)),
+        ("ObjectCreation test", Value::Integer(1000000)),
+        ("Regressions testSymbolEquality", Value::Integer(1)),
+        ("Regressions testSymbolReferenceEquality", Value::Integer(1)),
+        ("BinaryOperation test", Value::Integer(3 + 8)),
+        ("NumberOfTests numberOfTests", Value::Integer(52)),
+    ];
+
+    for (expr, expected) in tests {
+        println!("testing: '{}'", expr);
+
+        let mut lexer = Lexer::new(expr).skip_comments(true).skip_whitespace(true);
+        let tokens: Vec<Token> = lexer.by_ref().collect();
+        assert!(
+            lexer.text().is_empty(),
+            "could not fully tokenize test expression"
+        );
+
+        let (ast, rest) = lang::expression().parse(tokens.as_slice()).unwrap();
+        assert!(
+            rest.is_empty(),
+            "could not fully parse test expression: {:?}",
+            rest
+        );
+
+        let kind = FrameKind::Method {
+            holder: universe.system_class(),
+            self_value: Value::System,
+        };
+        let output = universe.with_frame(kind, |universe| ast.evaluate(universe));
+
+        match &output {
+            Return::Local(output) => assert_eq!(output, expected, "unexpected test output value"),
+            Return::NonLocal(_, _) => {
+                panic!("unexpected non-local return from basic interpreter test")
+            }
+            Return::Restart => panic!("unexpected `restart` from basic interpreter test"),
+            Return::Exception(err) => panic!("unexpected exception: '{}'", err),
+        }
+    }
+}

--- a/som-parser-text/src/lang.rs
+++ b/som-parser-text/src/lang.rs
@@ -242,7 +242,11 @@ pub fn unary_send<'a>() -> impl Parser<'a, Expression> {
     move |input: &'a [char]| {
         let (receiver, input) = primary().parse(input)?;
         let (_, input) = many(spacing()).parse(input)?;
-        let (signatures, input) = sep_by(many(spacing()), identifier()).parse(input)?;
+        let (signatures, input) = sep_by(
+            many(spacing()),
+            identifier().and_left(not(peek(exact(':')))),
+        )
+        .parse(input)?;
 
         let expr = signatures
             .into_iter()

--- a/som-parser-text/tests/tests.rs
+++ b/som-parser-text/tests/tests.rs
@@ -149,7 +149,7 @@ fn expression_test_2() {
 
 #[test]
 fn primary_test() {
-    let tokens: Vec<char> = "[ (self fib: (n - 1)) + (self fib: (n - 2)) ]"
+    let tokens: Vec<char> = "[ self fib: (n - 1) + (self fib: (n - 2)) ]"
         .chars()
         .collect();
     let parser = primary();
@@ -165,52 +165,45 @@ fn primary_test() {
             parameters: vec![],
             locals: vec![],
             body: Body {
-                exprs: vec![Expression::Term(Term {
-                    body: Body {
-                        exprs: vec![Expression::Message(Message {
-                            receiver: Box::new(Expression::Reference(String::from("self"))),
-                            signature: String::from("fib:"),
-                            values: vec![Expression::BinaryOp(BinaryOp {
-                                op: String::from("+"),
-                                lhs: Box::new(Expression::Term(Term {
-                                    body: Body {
-                                        exprs: vec![Expression::BinaryOp(BinaryOp {
-                                            op: String::from("-"),
-                                            lhs: Box::new(Expression::Reference(String::from("n"))),
-                                            rhs: Box::new(Expression::Literal(Literal::Integer(1))),
-                                        })],
-                                        full_stopped: false,
-                                    }
-                                })),
-                                rhs: Box::new(Expression::Term(Term {
-                                    body: Body {
-                                        exprs: vec![Expression::Message(Message {
-                                            receiver: Box::new(Expression::Reference(
-                                                String::from("self")
-                                            )),
-                                            signature: String::from("fib:"),
-                                            values: vec![Expression::Term(Term {
-                                                body: Body {
-                                                    exprs: vec![Expression::BinaryOp(BinaryOp {
-                                                        op: String::from("-"),
-                                                        lhs: Box::new(Expression::Reference(
-                                                            String::from("n")
-                                                        )),
-                                                        rhs: Box::new(Expression::Literal(
-                                                            Literal::Integer(2)
-                                                        )),
-                                                    })],
-                                                    full_stopped: false,
-                                                }
+                exprs: vec![Expression::Message(Message {
+                    receiver: Box::new(Expression::Reference(String::from("self"))),
+                    signature: String::from("fib:"),
+                    values: vec![Expression::BinaryOp(BinaryOp {
+                        op: String::from("+"),
+                        lhs: Box::new(Expression::Term(Term {
+                            body: Body {
+                                exprs: vec![Expression::BinaryOp(BinaryOp {
+                                    op: String::from("-"),
+                                    lhs: Box::new(Expression::Reference(String::from("n"))),
+                                    rhs: Box::new(Expression::Literal(Literal::Integer(1))),
+                                })],
+                                full_stopped: false,
+                            }
+                        })),
+                        rhs: Box::new(Expression::Term(Term {
+                            body: Body {
+                                exprs: vec![Expression::Message(Message {
+                                    receiver: Box::new(Expression::Reference(String::from("self"))),
+                                    signature: String::from("fib:"),
+                                    values: vec![Expression::Term(Term {
+                                        body: Body {
+                                            exprs: vec![Expression::BinaryOp(BinaryOp {
+                                                op: String::from("-"),
+                                                lhs: Box::new(Expression::Reference(String::from(
+                                                    "n"
+                                                ))),
+                                                rhs: Box::new(Expression::Literal(
+                                                    Literal::Integer(2)
+                                                )),
                                             })],
-                                        })],
-                                        full_stopped: false,
-                                    }
-                                }))
-                            })],
-                        })],
-                        full_stopped: false
-                    }
+                                            full_stopped: false,
+                                        }
+                                    })],
+                                })],
+                                full_stopped: false,
+                            }
+                        }))
+                    })],
                 })],
                 full_stopped: false,
             }


### PR DESCRIPTION
This PR adds support for running SOM's `BasicInterpreterTests` (a simpler subset of the SOM TestSuite) as an integration test for `som-rs`.  

The expected values for the tests are taken from `som-java`'s test runner for `BasicInterpreterTests` ([**here is the direct link**](https://github.com/SOM-st/som-java/blob/master/tests/som/tests/BasicInterpreterTests.java)).

We also add a CI workflow for running all of `som-rs`'s integrations tests (incl. the ones for `som-lexer` and `som-parser-*` crates) on pushes to master and on pull requests.