### PR TITLE
(opt): Inline caches for method lookups when sending messages

### DIFF
--- a/som-interpreter-bc/src/block.rs
+++ b/som-interpreter-bc/src/block.rs
@@ -1,10 +1,14 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::fmt;
+use std::rc::Rc;
 
 use som_core::bytecode::Bytecode;
 
 use crate::class::Class;
 use crate::compiler::Literal;
 use crate::frame::Frame;
+use crate::method::Method;
 use crate::universe::Universe;
 use crate::value::Value;
 use crate::SOMRef;
@@ -18,6 +22,7 @@ pub struct Block {
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
     pub nb_params: usize,
+    pub inline_cache: Rc<RefCell<HashMap<(*const Class, usize), Rc<Method>>>>,
 }
 
 impl Block {

--- a/som-interpreter-bc/src/block.rs
+++ b/som-interpreter-bc/src/block.rs
@@ -21,8 +21,7 @@ pub struct Block {
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
     pub nb_params: usize,
-    pub inline_cache_receiver: Rc<RefCell<Vec<*const Class>>>,
-    pub inline_cache_invocable: Rc<RefCell<Vec<Option<Rc<Method>>>>>,
+    pub inline_cache: Rc<RefCell<Vec<Option<(*const Class, Rc<Method>)>>>>,
 }
 
 impl Block {

--- a/som-interpreter-bc/src/block.rs
+++ b/som-interpreter-bc/src/block.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
 
@@ -22,7 +21,7 @@ pub struct Block {
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
     pub nb_params: usize,
-    pub inline_cache: Rc<RefCell<HashMap<(*const Class, usize), Rc<Method>>>>,
+    pub inline_cache: Rc<RefCell<Vec<Option<Rc<Method>>>>>,
 }
 
 impl Block {

--- a/som-interpreter-bc/src/block.rs
+++ b/som-interpreter-bc/src/block.rs
@@ -21,7 +21,8 @@ pub struct Block {
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
     pub nb_params: usize,
-    pub inline_cache: Rc<RefCell<Vec<Option<Rc<Method>>>>>,
+    pub inline_cache_receiver: Rc<RefCell<Vec<*const Class>>>,
+    pub inline_cache_invocable: Rc<RefCell<Vec<Option<Rc<Method>>>>>,
 }
 
 impl Block {

--- a/som-interpreter-bc/src/compiler.rs
+++ b/som-interpreter-bc/src/compiler.rs
@@ -414,15 +414,13 @@ fn compile_method(outer: &mut dyn GenCtxt, defn: &ast::MethodDef) -> Option<Meth
                 let body = ctxt.inner.body.unwrap_or_default();
                 let locals = ctxt.inner.locals.iter().map(|_| Value::Nil).collect();
                 let literals = ctxt.inner.literals.into_iter().collect();
-                let inline_cache_receiver = RefCell::new(vec![std::ptr::null(); body.len()]);
-                let inline_cache_invocable = RefCell::new(vec![None; body.len()]);
+                let inline_cache = RefCell::new(vec![None; body.len()]);
 
                 MethodKind::Defined(MethodEnv {
                     body,
                     locals,
                     literals,
-                    inline_cache_receiver,
-                    inline_cache_invocable,
+                    inline_cache,
                 })
             }
         },
@@ -461,8 +459,7 @@ fn compile_block(outer: &mut dyn GenCtxt, defn: &ast::Block) -> Option<Block> {
     let literals = ctxt.literals.into_iter().collect();
     let body = ctxt.body.unwrap_or_default();
     let nb_params = ctxt.args.len();
-    let inline_cache_receiver = Rc::new(RefCell::new(vec![std::ptr::null(); body.len()]));
-    let inline_cache_invocable = Rc::new(RefCell::new(vec![None; body.len()]));
+    let inline_cache = Rc::new(RefCell::new(vec![None; body.len()]));
 
     let block = Block {
         frame,
@@ -470,8 +467,7 @@ fn compile_block(outer: &mut dyn GenCtxt, defn: &ast::Block) -> Option<Block> {
         literals,
         body,
         nb_params,
-        inline_cache_receiver,
-        inline_cache_invocable,
+        inline_cache,
     };
 
     // println!("(system) compiled block !");

--- a/som-interpreter-bc/src/compiler.rs
+++ b/som-interpreter-bc/src/compiler.rs
@@ -2,6 +2,7 @@
 //! This is the bytecode compiler for the Simple Object Machine.
 //!
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::rc::{Rc, Weak};
 
@@ -415,6 +416,7 @@ fn compile_method(outer: &mut dyn GenCtxt, defn: &ast::MethodDef) -> Option<Meth
                     locals: ctxt.inner.locals.iter().map(|_| Value::Nil).collect(),
                     literals: ctxt.inner.literals.into_iter().collect(),
                     body: ctxt.inner.body.unwrap_or_default(),
+                    inline_cache: RefCell::new(HashMap::new()),
                 };
                 MethodKind::Defined(env)
             }
@@ -455,6 +457,7 @@ fn compile_block(outer: &mut dyn GenCtxt, defn: &ast::Block) -> Option<Block> {
         literals: ctxt.literals.into_iter().collect(),
         body: ctxt.body.unwrap_or_default(),
         nb_params: ctxt.args.len(),
+        inline_cache: Rc::new(RefCell::new(HashMap::new())),
     };
 
     // println!("(system) compiled block !");

--- a/som-interpreter-bc/src/compiler.rs
+++ b/som-interpreter-bc/src/compiler.rs
@@ -414,13 +414,15 @@ fn compile_method(outer: &mut dyn GenCtxt, defn: &ast::MethodDef) -> Option<Meth
                 let body = ctxt.inner.body.unwrap_or_default();
                 let locals = ctxt.inner.locals.iter().map(|_| Value::Nil).collect();
                 let literals = ctxt.inner.literals.into_iter().collect();
-                let inline_cache = RefCell::new(vec![None; body.len()]);
+                let inline_cache_receiver = RefCell::new(vec![std::ptr::null(); body.len()]);
+                let inline_cache_invocable = RefCell::new(vec![None; body.len()]);
 
                 MethodKind::Defined(MethodEnv {
                     body,
                     locals,
                     literals,
-                    inline_cache,
+                    inline_cache_receiver,
+                    inline_cache_invocable,
                 })
             }
         },
@@ -459,7 +461,8 @@ fn compile_block(outer: &mut dyn GenCtxt, defn: &ast::Block) -> Option<Block> {
     let literals = ctxt.literals.into_iter().collect();
     let body = ctxt.body.unwrap_or_default();
     let nb_params = ctxt.args.len();
-    let inline_cache = Rc::new(RefCell::new(vec![None; body.len()]));
+    let inline_cache_receiver = Rc::new(RefCell::new(vec![std::ptr::null(); body.len()]));
+    let inline_cache_invocable = Rc::new(RefCell::new(vec![None; body.len()]));
 
     let block = Block {
         frame,
@@ -467,7 +470,8 @@ fn compile_block(outer: &mut dyn GenCtxt, defn: &ast::Block) -> Option<Block> {
         literals,
         body,
         nb_params,
-        inline_cache,
+        inline_cache_receiver,
+        inline_cache_invocable,
     };
 
     // println!("(system) compiled block !");

--- a/som-interpreter-bc/src/interpreter.rs
+++ b/som-interpreter-bc/src/interpreter.rs
@@ -5,9 +5,11 @@ use std::time::Instant;
 use som_core::bytecode::Bytecode;
 
 use crate::block::Block;
+use crate::class::Class;
 use crate::compiler::Literal;
 use crate::frame::{Frame, FrameKind};
-use crate::method::MethodKind;
+use crate::interner::Interned;
+use crate::method::{Method, MethodKind};
 use crate::universe::Universe;
 use crate::value::Value;
 use crate::SOMRef;
@@ -188,240 +190,33 @@ impl Interpreter {
                 }
                 Bytecode::Send(idx) => {
                     let literal = frame.borrow().lookup_constant(idx as usize).unwrap();
-                    let symbol = match literal {
-                        Literal::Symbol(sym) => sym,
-                        _ => {
-                            return None;
-                        }
+                    let Literal::Symbol(symbol) = literal else {
+                        return None;
                     };
                     let signature = universe.lookup_symbol(symbol);
                     let nb_params = nb_params(signature);
                     let method = {
                         let receiver = self.stack.iter().nth_back(nb_params)?;
                         let receiver_class = receiver.class(universe);
-                        match frame.borrow().kind() {
-                            FrameKind::Block { block } => {
-                                let mut inline_cache = block.inline_cache.borrow_mut();
-
-                                // SAFETY: this access is actually safe because the bytecode compiler
-                                // makes sure the cache has as many entries as there are bytecode instructions,
-                                // therefore we can avoid doing any redundant bounds checks here.
-                                let maybe_found =
-                                    unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
-
-                                match maybe_found {
-                                    Some((receiver, method))
-                                        if *receiver == receiver_class.as_ptr() =>
-                                    {
-                                        Some(Rc::clone(method))
-                                    }
-                                    place => {
-                                        let found = receiver_class.borrow().lookup_method(symbol);
-                                        *place = found.clone().map(|method| {
-                                            (receiver_class.as_ptr() as *const _, method)
-                                        });
-                                        found
-                                    }
-                                }
-                            }
-                            FrameKind::Method { method, .. } => {
-                                if let MethodKind::Defined(env) = method.kind() {
-                                    let mut inline_cache = env.inline_cache.borrow_mut();
-
-                                    // SAFETY: this access is actually safe because the bytecode compiler
-                                    // makes sure the cache has as many entries as there are bytecode instructions,
-                                    // therefore we can avoid doing any redundant bounds checks here.
-                                    let maybe_found =
-                                        unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
-
-                                    match maybe_found {
-                                        Some((receiver, method))
-                                            if *receiver == receiver_class.as_ptr() =>
-                                        {
-                                            Some(Rc::clone(method))
-                                        }
-                                        place => {
-                                            let found =
-                                                receiver_class.borrow().lookup_method(symbol);
-                                            *place = found.clone().map(|method| {
-                                                (receiver_class.as_ptr() as *const _, method)
-                                            });
-                                            found
-                                        }
-                                    }
-                                } else {
-                                    receiver_class.borrow().lookup_method(symbol)
-                                }
-                            }
-                        }
+                        resolve_method(frame, &receiver_class, symbol, bytecode_idx)
                     };
 
-                    if let Some(method) = method {
-                        match method.kind() {
-                            MethodKind::Defined(_) => {
-                                let mut args = Vec::with_capacity(nb_params + 1);
-
-                                for _ in 0..nb_params {
-                                    let arg = self.stack.pop().unwrap();
-                                    args.push(arg);
-                                }
-                                let self_value = self.stack.pop().unwrap();
-                                args.push(self_value.clone());
-
-                                args.reverse();
-
-                                let holder = method.holder.upgrade().unwrap();
-                                let frame = self.push_frame(FrameKind::Method {
-                                    self_value,
-                                    method,
-                                    holder,
-                                });
-                                frame.borrow_mut().args = args;
-                            }
-                            MethodKind::Primitive(func) => {
-                                func(self, universe);
-                            }
-                            MethodKind::NotImplemented(err) => {
-                                let self_value = self.stack.iter().nth_back(nb_params).unwrap();
-                                println!(
-                                    "{}>>#{}",
-                                    self_value.class(&universe).borrow().name(),
-                                    method.signature()
-                                );
-                                panic!("Primitive `#{}` not implemented", err)
-                            }
-                        }
-                    } else {
-                        let mut args = Vec::with_capacity(nb_params + 1);
-
-                        for _ in 0..nb_params {
-                            let arg = self.stack.pop().unwrap();
-                            args.push(arg);
-                        }
-                        let self_value = self.stack.pop().unwrap();
-
-                        args.reverse();
-
-                        universe.does_not_understand(self, self_value, symbol, args)
-                            .expect(
-                                "A message cannot be handled and `doesNotUnderstand:arguments:` is not defined on receiver"
-                            );
-                    }
+                    do_send(self, universe, method, symbol, nb_params);
                 }
                 Bytecode::SuperSend(idx) => {
                     let literal = frame.borrow().lookup_constant(idx as usize).unwrap();
-                    let symbol = match literal {
-                        Literal::Symbol(sym) => sym,
-                        _ => {
-                            return None;
-                        }
+                    let Literal::Symbol(symbol) = literal else {
+                        return None;
                     };
                     let signature = universe.lookup_symbol(symbol);
                     let nb_params = nb_params(signature);
-                    let holder = frame.borrow().get_method_holder();
                     let method = {
+                        let holder = frame.borrow().get_method_holder();
                         let super_class = holder.borrow().super_class()?;
-                        match frame.borrow().kind() {
-                            FrameKind::Block { block } => {
-                                let mut inline_cache = block.inline_cache.borrow_mut();
-
-                                // SAFETY: this access is actually safe because the bytecode compiler
-                                // makes sure the cache has as many entries as there are bytecode instructions,
-                                // therefore we can avoid doing any redundant bounds checks here.
-                                let maybe_found =
-                                    unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
-
-                                match maybe_found {
-                                    Some((receiver, method))
-                                        if *receiver == super_class.as_ptr() =>
-                                    {
-                                        Some(Rc::clone(method))
-                                    }
-                                    place => {
-                                        let found = super_class.borrow().lookup_method(symbol);
-                                        *place = found.clone().map(|method| {
-                                            (super_class.as_ptr() as *const _, method)
-                                        });
-                                        found
-                                    }
-                                }
-                            }
-                            FrameKind::Method { method, .. } => {
-                                if let MethodKind::Defined(env) = method.kind() {
-                                    let mut inline_cache = env.inline_cache.borrow_mut();
-
-                                    // SAFETY: this access is actually safe because the bytecode compiler
-                                    // makes sure the cache has as many entries as there are bytecode instructions,
-                                    // therefore we can avoid doing any redundant bounds checks here.
-                                    let maybe_found =
-                                        unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
-
-                                    match maybe_found {
-                                        Some((receiver, method))
-                                            if *receiver == super_class.as_ptr() =>
-                                        {
-                                            Some(Rc::clone(method))
-                                        }
-                                        place => {
-                                            let found = super_class.borrow().lookup_method(symbol);
-                                            *place = found.clone().map(|method| {
-                                                (super_class.as_ptr() as *const _, method)
-                                            });
-                                            found
-                                        }
-                                    }
-                                } else {
-                                    super_class.borrow().lookup_method(symbol)
-                                }
-                            }
-                        }
+                        resolve_method(frame, &super_class, symbol, bytecode_idx)
                     };
 
-                    if let Some(method) = method {
-                        match method.kind() {
-                            MethodKind::Defined(_) => {
-                                let mut args = Vec::with_capacity(nb_params + 1);
-
-                                for _ in 0..nb_params {
-                                    let arg = self.stack.pop().unwrap();
-                                    args.push(arg);
-                                }
-                                let self_value = self.stack.pop().unwrap();
-                                args.push(self_value.clone());
-
-                                args.reverse();
-
-                                let holder = method.holder.upgrade().unwrap();
-                                let frame = self.push_frame(FrameKind::Method {
-                                    self_value,
-                                    method,
-                                    holder,
-                                });
-                                frame.borrow_mut().args = args;
-                            }
-                            MethodKind::Primitive(func) => {
-                                func(self, universe);
-                            }
-                            MethodKind::NotImplemented(err) => {
-                                panic!("Primitive `#{}` not implemented", err)
-                            }
-                        }
-                    } else {
-                        let mut args = Vec::with_capacity(nb_params + 1);
-
-                        for _ in 0..nb_params {
-                            let arg = self.stack.pop().unwrap();
-                            args.push(arg);
-                        }
-                        let self_value = self.stack.pop().unwrap();
-
-                        args.reverse();
-
-                        universe.does_not_understand(self, self_value, symbol, args)
-                            .expect(
-                                "A message cannot be handled and `doesNotUnderstand:arguments:` is not defined on receiver"
-                            );
-                    }
+                    do_send(self, universe, method, symbol, nb_params);
                 }
                 Bytecode::ReturnLocal => {
                     let value = self.stack.pop().unwrap();
@@ -457,6 +252,126 @@ impl Interpreter {
                         universe.escaped_block(self, instance, block).expect(
                             "A block has escaped and `escapedBlock:` is not defined on receiver",
                         );
+                    }
+                }
+            }
+        }
+
+        fn do_send(
+            interpreter: &mut Interpreter,
+            universe: &mut Universe,
+            method: Option<Rc<Method>>,
+            symbol: Interned,
+            nb_params: usize,
+        ) {
+            let Some(method) = method else {
+                let mut args = Vec::with_capacity(nb_params + 1);
+
+                for _ in 0..nb_params {
+                    let arg = interpreter.stack.pop().unwrap();
+                    args.push(arg);
+                }
+                let self_value = interpreter.stack.pop().unwrap();
+
+                args.reverse();
+
+                universe.does_not_understand(interpreter, self_value, symbol, args)
+                    .expect(
+                        "A message cannot be handled and `doesNotUnderstand:arguments:` is not defined on receiver"
+                    );
+                
+                return;
+            };
+    
+                match method.kind() {
+                    MethodKind::Defined(_) => {
+                        let mut args = Vec::with_capacity(nb_params + 1);
+
+                        for _ in 0..nb_params {
+                            let arg = interpreter.stack.pop().unwrap();
+                            args.push(arg);
+                        }
+                        let self_value = interpreter.stack.pop().unwrap();
+                        args.push(self_value.clone());
+
+                        args.reverse();
+
+                        let holder = method.holder.upgrade().unwrap();
+                        let frame = interpreter.push_frame(FrameKind::Method {
+                            self_value,
+                            method,
+                            holder,
+                        });
+                        frame.borrow_mut().args = args;
+                    }
+                    MethodKind::Primitive(func) => {
+                        func(interpreter, universe);
+                    }
+                    MethodKind::NotImplemented(err) => {
+                        let self_value = interpreter.stack.iter().nth_back(nb_params).unwrap();
+                        println!(
+                            "{}>>#{}",
+                            self_value.class(&universe).borrow().name(),
+                            method.signature(),
+                        );
+                        panic!("Primitive `#{}` not implemented", err)
+                    }
+                }
+        }
+
+        fn resolve_method(
+            frame: &SOMRef<Frame>,
+            class: &SOMRef<Class>,
+            signature: Interned,
+            bytecode_idx: usize,
+        ) -> Option<Rc<Method>> {
+            match frame.borrow().kind() {
+                FrameKind::Block { block } => {
+                    let mut inline_cache = block.inline_cache.borrow_mut();
+
+                    // SAFETY: this access is actually safe because the bytecode compiler
+                    // makes sure the cache has as many entries as there are bytecode instructions,
+                    // therefore we can avoid doing any redundant bounds checks here.
+                    let maybe_found = unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
+
+                    match maybe_found {
+                        Some((receiver, method)) if *receiver == class.as_ptr() => {
+                            Some(Rc::clone(method))
+                        }
+                        place @ None => {
+                            let found = class.borrow().lookup_method(signature);
+                            *place = found
+                                .clone()
+                                .map(|method| (class.as_ptr() as *const _, method));
+                            found
+                        }
+                        _ => class.borrow().lookup_method(signature),
+                    }
+                }
+                FrameKind::Method { method, .. } => {
+                    if let MethodKind::Defined(env) = method.kind() {
+                        let mut inline_cache = env.inline_cache.borrow_mut();
+
+                        // SAFETY: this access is actually safe because the bytecode compiler
+                        // makes sure the cache has as many entries as there are bytecode instructions,
+                        // therefore we can avoid doing any redundant bounds checks here.
+                        let maybe_found = unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
+
+                        match maybe_found {
+                            Some((receiver, method)) if *receiver == class.as_ptr() => {
+                                Some(Rc::clone(method))
+                            }
+                            place @ None => {
+                                let found = class.borrow().lookup_method(signature);
+                                *place = found
+                                    .clone()
+                                    .map(|method| (class.as_ptr() as *const _, method));
+                                found
+                            }
+                            _ => class.borrow().lookup_method(signature),
+                        }
+                    } else {
+                        class.borrow().lookup_method(signature)
                     }
                 }
             }

--- a/som-interpreter-bc/src/interpreter.rs
+++ b/som-interpreter-bc/src/interpreter.rs
@@ -279,44 +279,44 @@ impl Interpreter {
                     .expect(
                         "A message cannot be handled and `doesNotUnderstand:arguments:` is not defined on receiver"
                     );
-                
+
                 return;
             };
-    
-                match method.kind() {
-                    MethodKind::Defined(_) => {
-                        let mut args = Vec::with_capacity(nb_params + 1);
 
-                        for _ in 0..nb_params {
-                            let arg = interpreter.stack.pop().unwrap();
-                            args.push(arg);
-                        }
-                        let self_value = interpreter.stack.pop().unwrap();
-                        args.push(self_value.clone());
+            match method.kind() {
+                MethodKind::Defined(_) => {
+                    let mut args = Vec::with_capacity(nb_params + 1);
 
-                        args.reverse();
+                    for _ in 0..nb_params {
+                        let arg = interpreter.stack.pop().unwrap();
+                        args.push(arg);
+                    }
+                    let self_value = interpreter.stack.pop().unwrap();
+                    args.push(self_value.clone());
 
-                        let holder = method.holder.upgrade().unwrap();
-                        let frame = interpreter.push_frame(FrameKind::Method {
-                            self_value,
-                            method,
-                            holder,
-                        });
-                        frame.borrow_mut().args = args;
-                    }
-                    MethodKind::Primitive(func) => {
-                        func(interpreter, universe);
-                    }
-                    MethodKind::NotImplemented(err) => {
-                        let self_value = interpreter.stack.iter().nth_back(nb_params).unwrap();
-                        println!(
-                            "{}>>#{}",
-                            self_value.class(&universe).borrow().name(),
-                            method.signature(),
-                        );
-                        panic!("Primitive `#{}` not implemented", err)
-                    }
+                    args.reverse();
+
+                    let holder = method.holder.upgrade().unwrap();
+                    let frame = interpreter.push_frame(FrameKind::Method {
+                        self_value,
+                        method,
+                        holder,
+                    });
+                    frame.borrow_mut().args = args;
                 }
+                MethodKind::Primitive(func) => {
+                    func(interpreter, universe);
+                }
+                MethodKind::NotImplemented(err) => {
+                    let self_value = interpreter.stack.iter().nth_back(nb_params).unwrap();
+                    println!(
+                        "{}>>#{}",
+                        self_value.class(&universe).borrow().name(),
+                        method.signature(),
+                    );
+                    panic!("Primitive `#{}` not implemented", err)
+                }
+            }
         }
 
         fn resolve_method(

--- a/som-interpreter-bc/src/interpreter.rs
+++ b/som-interpreter-bc/src/interpreter.rs
@@ -201,36 +201,63 @@ impl Interpreter {
                         let receiver_class = receiver.class(universe);
                         match frame.borrow().kind() {
                             FrameKind::Block { block } => {
-                                let mut inline_cache = block.inline_cache.borrow_mut();
+                                let mut inline_cache_receiver =
+                                    block.inline_cache_receiver.borrow_mut();
+                                let mut inline_cache_invocable =
+                                    block.inline_cache_invocable.borrow_mut();
                                 // SAFETY: this access is actually safe because the bytecode compiler
                                 // makes sure the cache has as many entries as there are bytecode instructions,
                                 // therefore we can avoid doing any redundant bounds checks here.
-                                let maybe_found =
-                                    unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
-                                match maybe_found {
-                                    Some(method) => Some(Rc::clone(method)),
-                                    place @ None => {
-                                        let method = receiver_class.borrow().lookup_method(symbol);
-                                        *place = method.clone();
-                                        method
+                                let maybe_found_receiver = unsafe {
+                                    inline_cache_receiver.get_unchecked_mut(bytecode_idx)
+                                };
+                                let maybe_found_invocable = unsafe {
+                                    inline_cache_invocable.get_unchecked_mut(bytecode_idx)
+                                };
+
+                                match (maybe_found_receiver, maybe_found_invocable) {
+                                    (receiver, Some(method))
+                                        if *receiver == receiver_class.as_ptr() =>
+                                    {
+                                        Some(Rc::clone(method))
+                                    }
+                                    (receiver, method) => {
+                                        let found = receiver_class.borrow().lookup_method(symbol);
+                                        *receiver = receiver_class.as_ptr();
+                                        *method = found.clone();
+                                        found
                                     }
                                 }
                             }
                             FrameKind::Method { method, .. } => {
                                 if let MethodKind::Defined(env) = method.kind() {
-                                    let mut inline_cache = env.inline_cache.borrow_mut();
+                                    let mut inline_cache_receiver =
+                                        env.inline_cache_receiver.borrow_mut();
+                                    let mut inline_cache_invocable =
+                                        env.inline_cache_invocable.borrow_mut();
+
                                     // SAFETY: this access is actually safe because the bytecode compiler
                                     // makes sure the cache has as many entries as there are bytecode instructions,
                                     // therefore we can avoid doing any redundant bounds checks here.
-                                    let maybe_found =
-                                        unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
-                                    match maybe_found {
-                                        Some(method) => Some(Rc::clone(method)),
-                                        place @ None => {
-                                            let method =
+                                    let maybe_found_receiver = unsafe {
+                                        inline_cache_receiver.get_unchecked_mut(bytecode_idx)
+                                    };
+                                    let maybe_found_invocable = unsafe {
+                                        inline_cache_invocable.get_unchecked_mut(bytecode_idx)
+                                    };
+
+                                    match (maybe_found_receiver, maybe_found_invocable) {
+                                        (receiver, Some(method))
+                                            if *receiver == receiver_class.as_ptr() =>
+                                        {
+                                            Some(Rc::clone(method))
+                                        }
+                                        (receiver, method) => {
+                                            let found =
                                                 receiver_class.borrow().lookup_method(symbol);
-                                            *place = method.clone();
-                                            method
+                                            *receiver = receiver_class.as_ptr();
+                                            *method = found.clone();
+                                            found
                                         }
                                     }
                                 } else {
@@ -307,35 +334,63 @@ impl Interpreter {
                         let super_class = holder.borrow().super_class()?;
                         match frame.borrow().kind() {
                             FrameKind::Block { block } => {
-                                let mut inline_cache = block.inline_cache.borrow_mut();
+                                let mut inline_cache_receiver =
+                                    block.inline_cache_receiver.borrow_mut();
+                                let mut inline_cache_invocable =
+                                    block.inline_cache_invocable.borrow_mut();
+
                                 // SAFETY: this access is actually safe because the bytecode compiler
                                 // makes sure the cache has as many entries as there are bytecode instructions,
                                 // therefore we can avoid doing any redundant bounds checks here.
-                                let maybe_found =
-                                    unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
-                                match maybe_found {
-                                    Some(method) => Some(Rc::clone(method)),
-                                    place @ None => {
-                                        let method = super_class.borrow().lookup_method(symbol);
-                                        *place = method.clone();
-                                        method
+                                let maybe_found_receiver = unsafe {
+                                    inline_cache_receiver.get_unchecked_mut(bytecode_idx)
+                                };
+                                let maybe_found_invocable = unsafe {
+                                    inline_cache_invocable.get_unchecked_mut(bytecode_idx)
+                                };
+
+                                match (maybe_found_receiver, maybe_found_invocable) {
+                                    (receiver, Some(method))
+                                        if *receiver == super_class.as_ptr() =>
+                                    {
+                                        Some(Rc::clone(method))
+                                    }
+                                    (receiver, method) => {
+                                        let found = super_class.borrow().lookup_method(symbol);
+                                        *receiver = super_class.as_ptr();
+                                        *method = found.clone();
+                                        found
                                     }
                                 }
                             }
                             FrameKind::Method { method, .. } => {
                                 if let MethodKind::Defined(env) = method.kind() {
-                                    let mut inline_cache = env.inline_cache.borrow_mut();
+                                    let mut inline_cache_receiver =
+                                        env.inline_cache_receiver.borrow_mut();
+                                    let mut inline_cache_invocable =
+                                        env.inline_cache_invocable.borrow_mut();
+
                                     // SAFETY: this access is actually safe because the bytecode compiler
                                     // makes sure the cache has as many entries as there are bytecode instructions,
                                     // therefore we can avoid doing any redundant bounds checks here.
-                                    let maybe_found =
-                                        unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
-                                    match maybe_found {
-                                        Some(method) => Some(Rc::clone(method)),
-                                        place @ None => {
-                                            let method = super_class.borrow().lookup_method(symbol);
-                                            *place = method.clone();
-                                            method
+                                    let maybe_found_receiver = unsafe {
+                                        inline_cache_receiver.get_unchecked_mut(bytecode_idx)
+                                    };
+                                    let maybe_found_invocable = unsafe {
+                                        inline_cache_invocable.get_unchecked_mut(bytecode_idx)
+                                    };
+
+                                    match (maybe_found_receiver, maybe_found_invocable) {
+                                        (receiver, Some(method))
+                                            if *receiver == super_class.as_ptr() =>
+                                        {
+                                            Some(Rc::clone(method))
+                                        }
+                                        (receiver, method) => {
+                                            let found = super_class.borrow().lookup_method(symbol);
+                                            *receiver = super_class.as_ptr();
+                                            *method = found.clone();
+                                            found
                                         }
                                     }
                                 } else {

--- a/som-interpreter-bc/src/interpreter.rs
+++ b/som-interpreter-bc/src/interpreter.rs
@@ -201,62 +201,51 @@ impl Interpreter {
                         let receiver_class = receiver.class(universe);
                         match frame.borrow().kind() {
                             FrameKind::Block { block } => {
-                                let mut inline_cache_receiver =
-                                    block.inline_cache_receiver.borrow_mut();
-                                let mut inline_cache_invocable =
-                                    block.inline_cache_invocable.borrow_mut();
+                                let mut inline_cache = block.inline_cache.borrow_mut();
+
                                 // SAFETY: this access is actually safe because the bytecode compiler
                                 // makes sure the cache has as many entries as there are bytecode instructions,
                                 // therefore we can avoid doing any redundant bounds checks here.
-                                let maybe_found_receiver = unsafe {
-                                    inline_cache_receiver.get_unchecked_mut(bytecode_idx)
-                                };
-                                let maybe_found_invocable = unsafe {
-                                    inline_cache_invocable.get_unchecked_mut(bytecode_idx)
-                                };
+                                let maybe_found =
+                                    unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
 
-                                match (maybe_found_receiver, maybe_found_invocable) {
-                                    (receiver, Some(method))
+                                match maybe_found {
+                                    Some((receiver, method))
                                         if *receiver == receiver_class.as_ptr() =>
                                     {
                                         Some(Rc::clone(method))
                                     }
-                                    (receiver, method) => {
+                                    place => {
                                         let found = receiver_class.borrow().lookup_method(symbol);
-                                        *receiver = receiver_class.as_ptr();
-                                        *method = found.clone();
+                                        *place = found.clone().map(|method| {
+                                            (receiver_class.as_ptr() as *const _, method)
+                                        });
                                         found
                                     }
                                 }
                             }
                             FrameKind::Method { method, .. } => {
                                 if let MethodKind::Defined(env) = method.kind() {
-                                    let mut inline_cache_receiver =
-                                        env.inline_cache_receiver.borrow_mut();
-                                    let mut inline_cache_invocable =
-                                        env.inline_cache_invocable.borrow_mut();
+                                    let mut inline_cache = env.inline_cache.borrow_mut();
 
                                     // SAFETY: this access is actually safe because the bytecode compiler
                                     // makes sure the cache has as many entries as there are bytecode instructions,
                                     // therefore we can avoid doing any redundant bounds checks here.
-                                    let maybe_found_receiver = unsafe {
-                                        inline_cache_receiver.get_unchecked_mut(bytecode_idx)
-                                    };
-                                    let maybe_found_invocable = unsafe {
-                                        inline_cache_invocable.get_unchecked_mut(bytecode_idx)
-                                    };
+                                    let maybe_found =
+                                        unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
 
-                                    match (maybe_found_receiver, maybe_found_invocable) {
-                                        (receiver, Some(method))
+                                    match maybe_found {
+                                        Some((receiver, method))
                                             if *receiver == receiver_class.as_ptr() =>
                                         {
                                             Some(Rc::clone(method))
                                         }
-                                        (receiver, method) => {
+                                        place => {
                                             let found =
                                                 receiver_class.borrow().lookup_method(symbol);
-                                            *receiver = receiver_class.as_ptr();
-                                            *method = found.clone();
+                                            *place = found.clone().map(|method| {
+                                                (receiver_class.as_ptr() as *const _, method)
+                                            });
                                             found
                                         }
                                     }
@@ -334,62 +323,50 @@ impl Interpreter {
                         let super_class = holder.borrow().super_class()?;
                         match frame.borrow().kind() {
                             FrameKind::Block { block } => {
-                                let mut inline_cache_receiver =
-                                    block.inline_cache_receiver.borrow_mut();
-                                let mut inline_cache_invocable =
-                                    block.inline_cache_invocable.borrow_mut();
+                                let mut inline_cache = block.inline_cache.borrow_mut();
 
                                 // SAFETY: this access is actually safe because the bytecode compiler
                                 // makes sure the cache has as many entries as there are bytecode instructions,
                                 // therefore we can avoid doing any redundant bounds checks here.
-                                let maybe_found_receiver = unsafe {
-                                    inline_cache_receiver.get_unchecked_mut(bytecode_idx)
-                                };
-                                let maybe_found_invocable = unsafe {
-                                    inline_cache_invocable.get_unchecked_mut(bytecode_idx)
-                                };
+                                let maybe_found =
+                                    unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
 
-                                match (maybe_found_receiver, maybe_found_invocable) {
-                                    (receiver, Some(method))
+                                match maybe_found {
+                                    Some((receiver, method))
                                         if *receiver == super_class.as_ptr() =>
                                     {
                                         Some(Rc::clone(method))
                                     }
-                                    (receiver, method) => {
+                                    place => {
                                         let found = super_class.borrow().lookup_method(symbol);
-                                        *receiver = super_class.as_ptr();
-                                        *method = found.clone();
+                                        *place = found.clone().map(|method| {
+                                            (super_class.as_ptr() as *const _, method)
+                                        });
                                         found
                                     }
                                 }
                             }
                             FrameKind::Method { method, .. } => {
                                 if let MethodKind::Defined(env) = method.kind() {
-                                    let mut inline_cache_receiver =
-                                        env.inline_cache_receiver.borrow_mut();
-                                    let mut inline_cache_invocable =
-                                        env.inline_cache_invocable.borrow_mut();
+                                    let mut inline_cache = env.inline_cache.borrow_mut();
 
                                     // SAFETY: this access is actually safe because the bytecode compiler
                                     // makes sure the cache has as many entries as there are bytecode instructions,
                                     // therefore we can avoid doing any redundant bounds checks here.
-                                    let maybe_found_receiver = unsafe {
-                                        inline_cache_receiver.get_unchecked_mut(bytecode_idx)
-                                    };
-                                    let maybe_found_invocable = unsafe {
-                                        inline_cache_invocable.get_unchecked_mut(bytecode_idx)
-                                    };
+                                    let maybe_found =
+                                        unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
 
-                                    match (maybe_found_receiver, maybe_found_invocable) {
-                                        (receiver, Some(method))
+                                    match maybe_found {
+                                        Some((receiver, method))
                                             if *receiver == super_class.as_ptr() =>
                                         {
                                             Some(Rc::clone(method))
                                         }
-                                        (receiver, method) => {
+                                        place => {
                                             let found = super_class.borrow().lookup_method(symbol);
-                                            *receiver = super_class.as_ptr();
-                                            *method = found.clone();
+                                            *place = found.clone().map(|method| {
+                                                (super_class.as_ptr() as *const _, method)
+                                            });
                                             found
                                         }
                                     }

--- a/som-interpreter-bc/src/method.rs
+++ b/som-interpreter-bc/src/method.rs
@@ -18,7 +18,8 @@ pub struct MethodEnv {
     pub locals: Vec<Value>,
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
-    pub inline_cache: RefCell<Vec<Option<Rc<Method>>>>,
+    pub inline_cache_receiver: RefCell<Vec<*const Class>>,
+    pub inline_cache_invocable: RefCell<Vec<Option<Rc<Method>>>>,
 }
 
 /// The kind of a class method.

--- a/som-interpreter-bc/src/method.rs
+++ b/som-interpreter-bc/src/method.rs
@@ -18,8 +18,7 @@ pub struct MethodEnv {
     pub locals: Vec<Value>,
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
-    pub inline_cache_receiver: RefCell<Vec<*const Class>>,
-    pub inline_cache_invocable: RefCell<Vec<Option<Rc<Method>>>>,
+    pub inline_cache: RefCell<Vec<Option<(*const Class, Rc<Method>)>>>,
 }
 
 /// The kind of a class method.

--- a/som-interpreter-bc/src/method.rs
+++ b/som-interpreter-bc/src/method.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
 
@@ -17,6 +19,7 @@ pub struct MethodEnv {
     pub locals: Vec<Value>,
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
+    pub inline_cache: RefCell<HashMap<(*const Class, usize), Rc<Method>>>,
 }
 
 /// The kind of a class method.

--- a/som-interpreter-bc/src/method.rs
+++ b/som-interpreter-bc/src/method.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
 
@@ -19,7 +18,7 @@ pub struct MethodEnv {
     pub locals: Vec<Value>,
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
-    pub inline_cache: RefCell<HashMap<(*const Class, usize), Rc<Method>>>,
+    pub inline_cache: RefCell<Vec<Option<Rc<Method>>>>,
 }
 
 /// The kind of a class method.


### PR DESCRIPTION
This PR adds caches to do faster method resolutions when the receiver class and the call site is the same, as a potential optimization (yet to be measured to see if it's an actual win).

This PR only affects the bytecode interpreter.

**Depends on #11.**
