### PR TITLE
(opt): Single shared interpreter evaluation stack

### DIFF
--- a/som-interpreter-bc/src/block.rs
+++ b/som-interpreter-bc/src/block.rs
@@ -27,7 +27,7 @@ impl Block {
             0 => universe.block1_class(),
             1 => universe.block2_class(),
             2 => universe.block3_class(),
-            _ => panic!("no support for blocks with more than 2 paramters"),
+            _ => panic!("no support for blocks with more than 2 parameters"),
         }
     }
 

--- a/som-interpreter-bc/src/frame.rs
+++ b/som-interpreter-bc/src/frame.rs
@@ -36,8 +36,6 @@ pub struct Frame {
     pub args: Vec<Value>,
     /// The bindings within this frame.
     pub locals: Vec<Value>,
-    /// Execution stack.
-    pub stack: Vec<Value>,
     /// Bytecode index.
     pub bytecode_idx: usize,
 }
@@ -52,7 +50,6 @@ impl Frame {
                     kind,
                     locals,
                     args: vec![],
-                    stack: vec![],
                     bytecode_idx: 0,
                 }
             }
@@ -63,7 +60,6 @@ impl Frame {
                         kind,
                         locals,
                         args: vec![],
-                        stack: vec![],
                         bytecode_idx: 0,
                     }
                 } else {
@@ -71,7 +67,6 @@ impl Frame {
                         kind,
                         locals: vec![],
                         args: vec![],
-                        stack: vec![],
                         bytecode_idx: 0,
                     }
                 }

--- a/som-interpreter-bc/src/interpreter.rs
+++ b/som-interpreter-bc/src/interpreter.rs
@@ -48,7 +48,7 @@ impl Interpreter {
         loop {
             let frame = match self.current_frame() {
                 Some(frame) => frame,
-                None => return Some(Value::Nil),
+                None => return Some(self.stack.pop().unwrap_or(Value::Nil)),
             };
 
             let opt_bytecode = frame.borrow().get_current_bytecode();

--- a/som-interpreter-bc/src/method.rs
+++ b/som-interpreter-bc/src/method.rs
@@ -129,9 +129,8 @@ impl Method {
                 frame.borrow_mut().args.append(&mut args);
             }
             MethodKind::Primitive(func) => {
-                let frame = interpreter.current_frame().unwrap();
-                frame.borrow_mut().stack.push(receiver);
-                frame.borrow_mut().stack.append(&mut args);
+                interpreter.stack.push(receiver);
+                interpreter.stack.append(&mut args);
                 func(interpreter, universe)
             }
             MethodKind::NotImplemented(_) => todo!(),

--- a/som-interpreter-bc/src/primitives/array.rs
+++ b/som-interpreter-bc/src/primitives/array.rs
@@ -11,9 +11,7 @@ use crate::{expect_args, reverse};
 fn at(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Array>>#at:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         Value::Array(values) => values,
         Value::Integer(index) => index,
     ]);
@@ -23,15 +21,13 @@ fn at(interpreter: &mut Interpreter, _: &mut Universe) {
         Err(err) => panic!("'{}': {}", SIGNATURE, err),
     };
     let value = values.borrow().get(index).cloned().unwrap_or(Value::Nil);
-    frame.borrow_mut().stack.push(value)
+    interpreter.stack.push(value)
 }
 
 fn at_put(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Array>>#at:put:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         Value::Array(values) => values,
         Value::Integer(index) => index,
         value => value,
@@ -44,21 +40,19 @@ fn at_put(interpreter: &mut Interpreter, _: &mut Universe) {
     if let Some(location) = values.borrow_mut().get_mut(index) {
         *location = value;
     }
-    frame.borrow_mut().stack.push(Value::Array(values))
+    interpreter.stack.push(Value::Array(values))
 }
 
 fn length(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Array>>#length";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         Value::Array(values) => values,
     ]);
 
     let length = values.borrow().len();
     match i64::try_from(length) {
-        Ok(length) => frame.borrow_mut().stack.push(Value::Integer(length)),
+        Ok(length) => interpreter.stack.push(Value::Integer(length)),
         Err(err) => panic!("'{}': {}", SIGNATURE, err),
     }
 }
@@ -66,16 +60,13 @@ fn length(interpreter: &mut Interpreter, _: &mut Universe) {
 fn new(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Array>>#new:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         _,
         Value::Integer(count) => count,
     ]);
 
     match usize::try_from(count) {
-        Ok(length) => frame
-            .borrow_mut()
+        Ok(length) => interpreter
             .stack
             .push(Value::Array(Rc::new(RefCell::new(vec![
                 Value::Nil;

--- a/som-interpreter-bc/src/primitives/blocks.rs
+++ b/som-interpreter-bc/src/primitives/blocks.rs
@@ -12,9 +12,7 @@ pub mod block1 {
     fn value(interpreter: &mut Interpreter, _: &mut Universe) {
         const SIGNATURE: &str = "Block1>>#value";
 
-        let frame = interpreter.current_frame().expect("no current frame");
-
-        expect_args!(SIGNATURE, frame, [
+        expect_args!(SIGNATURE, interpreter, [
             Value::Block(block) => block,
         ]);
 
@@ -28,10 +26,9 @@ pub mod block1 {
     fn restart(interpreter: &mut Interpreter, _: &mut Universe) {
         const SIGNATURE: &str = "Block>>#restart";
 
+        expect_args!(SIGNATURE, interpreter, [Value::Block(_)]);
+
         let frame = interpreter.current_frame().expect("no current frame");
-
-        expect_args!(SIGNATURE, frame, [Value::Block(_)]);
-
         frame.borrow_mut().bytecode_idx = 0;
     }
 
@@ -52,9 +49,7 @@ pub mod block2 {
     fn value(interpreter: &mut Interpreter, _: &mut Universe) {
         const SIGNATURE: &str = "Block2>>#value:";
 
-        let frame = interpreter.current_frame().expect("no current frame");
-
-        expect_args!(SIGNATURE, frame, [
+        expect_args!(SIGNATURE, interpreter, [
             Value::Block(block) => block,
             argument => argument,
         ]);
@@ -83,9 +78,7 @@ pub mod block3 {
     fn value_with(interpreter: &mut Interpreter, _: &mut Universe) {
         const SIGNATURE: &str = "Block3>>#value:with:";
 
-        let frame = interpreter.current_frame().expect("no current frame");
-
-        expect_args!(SIGNATURE, frame, [
+        expect_args!(SIGNATURE, interpreter, [
             Value::Block(block) => block,
             argument1 => argument1,
             argument2 => argument2,

--- a/som-interpreter-bc/src/primitives/double.rs
+++ b/som-interpreter-bc/src/primitives/double.rs
@@ -22,15 +22,13 @@ macro_rules! promote {
 fn from_string(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#fromString:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         _,
         Value::String(string) => string,
     ]);
 
     match string.parse() {
-        Ok(parsed) => frame.borrow_mut().stack.push(Value::Double(parsed)),
+        Ok(parsed) => interpreter.stack.push(Value::Double(parsed)),
         Err(err) => panic!("'{}': {}", SIGNATURE, err),
     }
 }
@@ -38,16 +36,13 @@ fn from_string(interpreter: &mut Interpreter, _: &mut Universe) {
 fn as_string(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#asString";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         value => value,
     ]);
 
     let value = promote!(SIGNATURE, value);
 
-    frame
-        .borrow_mut()
+    interpreter
         .stack
         .push(Value::String(Rc::new(value.to_string())));
 }
@@ -55,95 +50,78 @@ fn as_string(interpreter: &mut Interpreter, _: &mut Universe) {
 fn as_integer(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#asInteger";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         Value::Double(value) => value,
     ]);
 
-    frame
-        .borrow_mut()
-        .stack
-        .push(Value::Integer(value.trunc() as i64));
+    interpreter.stack.push(Value::Integer(value.trunc() as i64));
 }
 
 fn sqrt(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#sqrt";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         value => value,
     ]);
 
     let value = promote!(SIGNATURE, value);
 
-    frame.borrow_mut().stack.push(Value::Double(value.sqrt()));
+    interpreter.stack.push(Value::Double(value.sqrt()));
 }
 
 fn round(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#round";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         value => value,
     ]);
 
     let value = promote!(SIGNATURE, value);
 
-    frame.borrow_mut().stack.push(Value::Double(value.round()));
+    interpreter.stack.push(Value::Double(value.round()));
 }
 
 fn cos(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#cos";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         value => value,
     ]);
 
     let value = promote!(SIGNATURE, value);
 
-    frame.borrow_mut().stack.push(Value::Double(value.cos()));
+    interpreter.stack.push(Value::Double(value.cos()));
 }
 
 fn sin(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#sin";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         value => value,
     ]);
 
     let value = promote!(SIGNATURE, value);
 
-    frame.borrow_mut().stack.push(Value::Double(value.sin()));
+    interpreter.stack.push(Value::Double(value.sin()));
 }
 
 fn eq(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#=";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         // Value::Double(a) => a,
         // Value::Double(b) => b,
         a => a,
         b => b,
     ]);
 
-    frame.borrow_mut().stack.push(Value::Boolean(a == b));
+    interpreter.stack.push(Value::Boolean(a == b));
 }
 
 fn lt(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#<";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
@@ -151,15 +129,13 @@ fn lt(interpreter: &mut Interpreter, _: &mut Universe) {
     let a = promote!(SIGNATURE, a);
     let b = promote!(SIGNATURE, b);
 
-    frame.borrow_mut().stack.push(Value::Boolean(a < b));
+    interpreter.stack.push(Value::Boolean(a < b));
 }
 
 fn plus(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#+";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
@@ -167,15 +143,13 @@ fn plus(interpreter: &mut Interpreter, _: &mut Universe) {
     let a = promote!(SIGNATURE, a);
     let b = promote!(SIGNATURE, b);
 
-    frame.borrow_mut().stack.push(Value::Double(a + b));
+    interpreter.stack.push(Value::Double(a + b));
 }
 
 fn minus(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#-";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
@@ -183,15 +157,13 @@ fn minus(interpreter: &mut Interpreter, _: &mut Universe) {
     let a = promote!(SIGNATURE, a);
     let b = promote!(SIGNATURE, b);
 
-    frame.borrow_mut().stack.push(Value::Double(a - b));
+    interpreter.stack.push(Value::Double(a - b));
 }
 
 fn times(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#*";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
@@ -199,15 +171,13 @@ fn times(interpreter: &mut Interpreter, _: &mut Universe) {
     let a = promote!(SIGNATURE, a);
     let b = promote!(SIGNATURE, b);
 
-    frame.borrow_mut().stack.push(Value::Double(a * b));
+    interpreter.stack.push(Value::Double(a * b));
 }
 
 fn divide(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#//";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
@@ -215,15 +185,13 @@ fn divide(interpreter: &mut Interpreter, _: &mut Universe) {
     let a = promote!(SIGNATURE, a);
     let b = promote!(SIGNATURE, b);
 
-    frame.borrow_mut().stack.push(Value::Double(a / b));
+    interpreter.stack.push(Value::Double(a / b));
 }
 
 fn modulo(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#%";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
@@ -231,19 +199,15 @@ fn modulo(interpreter: &mut Interpreter, _: &mut Universe) {
     let a = promote!(SIGNATURE, a);
     let b = promote!(SIGNATURE, b);
 
-    frame.borrow_mut().stack.push(Value::Double(a % b));
+    interpreter.stack.push(Value::Double(a % b));
 }
 
 fn positive_infinity(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#positiveInfinity";
 
-    let frame = interpreter.current_frame().expect("no current frame");
+    expect_args!(SIGNATURE, interpreter, [_]);
 
-    expect_args!(SIGNATURE, frame, [_]);
-
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    frame.borrow_mut().stack.push(Value::Double(f64::INFINITY));
+    interpreter.stack.push(Value::Double(f64::INFINITY));
 }
 
 /// Search for a primitive matching the given signature.

--- a/som-interpreter-bc/src/primitives/integer.rs
+++ b/som-interpreter-bc/src/primitives/integer.rs
@@ -12,15 +12,15 @@ use crate::value::Value;
 use crate::{expect_args, reverse};
 
 macro_rules! demote {
-    ($frame:expr, $expr:expr) => {{
+    ($interpreter:expr, $expr:expr) => {{
         let value = $expr;
         match value.to_i64() {
             Some(value) => {
-                $frame.borrow_mut().stack.push(Value::Integer(value));
+                $interpreter.stack.push(Value::Integer(value));
                 return;
             }
             None => {
-                $frame.borrow_mut().stack.push(Value::BigInteger(value));
+                $interpreter.stack.push(Value::BigInteger(value));
                 return;
             }
         }
@@ -30,9 +30,7 @@ macro_rules! demote {
 fn from_string(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#fromString:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         _,
         value => value,
     ]);
@@ -48,7 +46,7 @@ fn from_string(interpreter: &mut Interpreter, universe: &mut Universe) {
 
     match parsed {
         Ok(parsed) => {
-            frame.borrow_mut().stack.push(parsed);
+            interpreter.stack.push(parsed);
             return;
         }
         Err(err) => panic!("{}", err),
@@ -58,9 +56,7 @@ fn from_string(interpreter: &mut Interpreter, universe: &mut Universe) {
 fn as_string(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#asString";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         value => value,
     ]);
 
@@ -71,7 +67,7 @@ fn as_string(interpreter: &mut Interpreter, _: &mut Universe) {
     };
 
     {
-        frame.borrow_mut().stack.push(Value::String(Rc::new(value)));
+        interpreter.stack.push(Value::String(Rc::new(value)));
         return;
     }
 }
@@ -79,9 +75,7 @@ fn as_string(interpreter: &mut Interpreter, _: &mut Universe) {
 fn at_random(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#atRandom";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         value => value,
     ]);
 
@@ -99,7 +93,7 @@ fn at_random(interpreter: &mut Interpreter, _: &mut Universe) {
     };
 
     {
-        frame.borrow_mut().stack.push(Value::Integer(chosen));
+        interpreter.stack.push(Value::Integer(chosen));
         return;
     }
 }
@@ -107,9 +101,7 @@ fn at_random(interpreter: &mut Interpreter, _: &mut Universe) {
 fn as_32bit_signed_value(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#as32BitSignedValue";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         value => value,
     ]);
 
@@ -123,7 +115,7 @@ fn as_32bit_signed_value(interpreter: &mut Interpreter, _: &mut Universe) {
     };
 
     {
-        frame.borrow_mut().stack.push(Value::Integer(value));
+        interpreter.stack.push(Value::Integer(value));
         return;
     }
 }
@@ -131,9 +123,7 @@ fn as_32bit_signed_value(interpreter: &mut Interpreter, _: &mut Universe) {
 fn as_32bit_unsigned_value(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#as32BitUnsignedValue";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         value => value,
     ]);
 
@@ -147,7 +137,7 @@ fn as_32bit_unsigned_value(interpreter: &mut Interpreter, _: &mut Universe) {
     };
 
     {
-        frame.borrow_mut().stack.push(Value::Integer(value));
+        interpreter.stack.push(Value::Integer(value));
         return;
     }
 }
@@ -155,9 +145,7 @@ fn as_32bit_unsigned_value(interpreter: &mut Interpreter, _: &mut Universe) {
 fn plus(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#+";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
@@ -165,21 +153,21 @@ fn plus(interpreter: &mut Interpreter, _: &mut Universe) {
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => match a.checked_add(b) {
             Some(value) => {
-                frame.borrow_mut().stack.push(Value::Integer(value));
+                interpreter.stack.push(Value::Integer(value));
                 return;
             }
-            None => demote!(frame, BigInt::from(a) + BigInt::from(b)),
+            None => demote!(interpreter, BigInt::from(a) + BigInt::from(b)),
         },
-        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(frame, a + b),
+        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(interpreter, a + b),
         (Value::BigInteger(a), Value::Integer(b)) | (Value::Integer(b), Value::BigInteger(a)) => {
-            demote!(frame, a + BigInt::from(b))
+            demote!(interpreter, a + BigInt::from(b))
         }
         (Value::Double(a), Value::Double(b)) => {
-            frame.borrow_mut().stack.push(Value::Double(a + b));
+            interpreter.stack.push(Value::Double(a + b));
             return;
         }
         (Value::Integer(a), Value::Double(b)) | (Value::Double(b), Value::Integer(a)) => {
-            frame.borrow_mut().stack.push(Value::Double((a as f64) + b));
+            interpreter.stack.push(Value::Double((a as f64) + b));
             return;
         }
         _ => panic!("'{}': wrong types", SIGNATURE),
@@ -189,9 +177,7 @@ fn plus(interpreter: &mut Interpreter, _: &mut Universe) {
 fn minus(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#-";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
@@ -199,21 +185,21 @@ fn minus(interpreter: &mut Interpreter, _: &mut Universe) {
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => match a.checked_sub(b) {
             Some(value) => {
-                frame.borrow_mut().stack.push(Value::Integer(value));
+                interpreter.stack.push(Value::Integer(value));
                 return;
             }
-            None => demote!(frame, BigInt::from(a) - BigInt::from(b)),
+            None => demote!(interpreter, BigInt::from(a) - BigInt::from(b)),
         },
-        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(frame, a - b),
+        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(interpreter, a - b),
         (Value::BigInteger(a), Value::Integer(b)) | (Value::Integer(b), Value::BigInteger(a)) => {
-            demote!(frame, a - BigInt::from(b))
+            demote!(interpreter, a - BigInt::from(b))
         }
         (Value::Double(a), Value::Double(b)) => {
-            frame.borrow_mut().stack.push(Value::Double(a - b));
+            interpreter.stack.push(Value::Double(a - b));
             return;
         }
         (Value::Integer(a), Value::Double(b)) | (Value::Double(b), Value::Integer(a)) => {
-            frame.borrow_mut().stack.push(Value::Double((a as f64) - b));
+            interpreter.stack.push(Value::Double((a as f64) - b));
             return;
         }
         _ => panic!("'{}': wrong types", SIGNATURE),
@@ -223,9 +209,7 @@ fn minus(interpreter: &mut Interpreter, _: &mut Universe) {
 fn times(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#*";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
@@ -233,21 +217,21 @@ fn times(interpreter: &mut Interpreter, _: &mut Universe) {
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => match a.checked_mul(b) {
             Some(value) => {
-                frame.borrow_mut().stack.push(Value::Integer(value));
+                interpreter.stack.push(Value::Integer(value));
                 return;
             }
-            None => demote!(frame, BigInt::from(a) * BigInt::from(b)),
+            None => demote!(interpreter, BigInt::from(a) * BigInt::from(b)),
         },
-        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(frame, a * b),
+        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(interpreter, a * b),
         (Value::BigInteger(a), Value::Integer(b)) | (Value::Integer(b), Value::BigInteger(a)) => {
-            demote!(frame, a * BigInt::from(b))
+            demote!(interpreter, a * BigInt::from(b))
         }
         (Value::Double(a), Value::Double(b)) => {
-            frame.borrow_mut().stack.push(Value::Double(a * b));
+            interpreter.stack.push(Value::Double(a * b));
             return;
         }
         (Value::Integer(a), Value::Double(b)) | (Value::Double(b), Value::Integer(a)) => {
-            frame.borrow_mut().stack.push(Value::Double((a as f64) * b));
+            interpreter.stack.push(Value::Double((a as f64) * b));
             return;
         }
         _ => panic!("'{}': wrong types", SIGNATURE),
@@ -257,9 +241,7 @@ fn times(interpreter: &mut Interpreter, _: &mut Universe) {
 fn divide(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#/";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
@@ -267,21 +249,21 @@ fn divide(interpreter: &mut Interpreter, _: &mut Universe) {
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => match a.checked_div(b) {
             Some(value) => {
-                frame.borrow_mut().stack.push(Value::Integer(value));
+                interpreter.stack.push(Value::Integer(value));
                 return;
             }
-            None => demote!(frame, BigInt::from(a) / BigInt::from(b)),
+            None => demote!(interpreter, BigInt::from(a) / BigInt::from(b)),
         },
-        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(frame, a / b),
+        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(interpreter, a / b),
         (Value::BigInteger(a), Value::Integer(b)) | (Value::Integer(b), Value::BigInteger(a)) => {
-            demote!(frame, a / BigInt::from(b))
+            demote!(interpreter, a / BigInt::from(b))
         }
         (Value::Double(a), Value::Double(b)) => {
-            frame.borrow_mut().stack.push(Value::Double(a / b));
+            interpreter.stack.push(Value::Double(a / b));
             return;
         }
         (Value::Integer(a), Value::Double(b)) | (Value::Double(b), Value::Integer(a)) => {
-            frame.borrow_mut().stack.push(Value::Double((a as f64) / b));
+            interpreter.stack.push(Value::Double((a as f64) / b));
             return;
         }
         _ => panic!("'{}': wrong types", SIGNATURE),
@@ -291,27 +273,24 @@ fn divide(interpreter: &mut Interpreter, _: &mut Universe) {
 fn divide_float(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#//";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
 
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => {
-            frame
-                .borrow_mut()
+            interpreter
                 .stack
                 .push(Value::Double((a as f64) / (b as f64)));
             return;
         }
         (Value::Integer(a), Value::Double(b)) | (Value::Double(b), Value::Integer(a)) => {
-            frame.borrow_mut().stack.push(Value::Double((a as f64) / b));
+            interpreter.stack.push(Value::Double((a as f64) / b));
             return;
         }
         (Value::Double(a), Value::Double(b)) => {
-            frame.borrow_mut().stack.push(Value::Double(a / b));
+            interpreter.stack.push(Value::Double(a / b));
             return;
         }
         _ => panic!("'{}': wrong types", SIGNATURE),
@@ -321,9 +300,7 @@ fn divide_float(interpreter: &mut Interpreter, _: &mut Universe) {
 fn modulo(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#%";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         Value::Integer(a) => a,
         Value::Integer(b) => b,
     ]);
@@ -331,15 +308,12 @@ fn modulo(interpreter: &mut Interpreter, _: &mut Universe) {
     let result = a % b;
     if result.signum() != b.signum() {
         {
-            frame
-                .borrow_mut()
-                .stack
-                .push(Value::Integer((result + b) % b));
+            interpreter.stack.push(Value::Integer((result + b) % b));
             return;
         }
     } else {
         {
-            frame.borrow_mut().stack.push(Value::Integer(result));
+            interpreter.stack.push(Value::Integer(result));
             return;
         }
     }
@@ -348,9 +322,7 @@ fn modulo(interpreter: &mut Interpreter, _: &mut Universe) {
 fn remainder(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#rem:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         Value::Integer(a) => a,
         Value::Integer(b) => b,
     ]);
@@ -358,15 +330,12 @@ fn remainder(interpreter: &mut Interpreter, _: &mut Universe) {
     let result = a % b;
     if result.signum() != a.signum() {
         {
-            frame
-                .borrow_mut()
-                .stack
-                .push(Value::Integer((result + a) % a));
+            interpreter.stack.push(Value::Integer((result + a) % a));
             return;
         }
     } else {
         {
-            frame.borrow_mut().stack.push(Value::Integer(result));
+            interpreter.stack.push(Value::Integer(result));
             return;
         }
     }
@@ -375,9 +344,7 @@ fn remainder(interpreter: &mut Interpreter, _: &mut Universe) {
 fn sqrt(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#sqrt";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
     ]);
 
@@ -387,22 +354,19 @@ fn sqrt(interpreter: &mut Interpreter, _: &mut Universe) {
             let trucated = sqrt.trunc();
             if sqrt == trucated {
                 {
-                    frame
-                        .borrow_mut()
-                        .stack
-                        .push(Value::Integer(trucated as i64));
+                    interpreter.stack.push(Value::Integer(trucated as i64));
                     return;
                 }
             } else {
                 {
-                    frame.borrow_mut().stack.push(Value::Double(sqrt));
+                    interpreter.stack.push(Value::Double(sqrt));
                     return;
                 }
             }
         }
-        Value::BigInteger(a) => demote!(frame, a.sqrt()),
+        Value::BigInteger(a) => demote!(interpreter, a.sqrt()),
         Value::Double(a) => {
-            frame.borrow_mut().stack.push(Value::Double(a.sqrt()));
+            interpreter.stack.push(Value::Double(a.sqrt()));
             return;
         }
         _ => panic!("'{}': wrong types", SIGNATURE),
@@ -412,21 +376,19 @@ fn sqrt(interpreter: &mut Interpreter, _: &mut Universe) {
 fn bitand(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#&";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
 
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => {
-            frame.borrow_mut().stack.push(Value::Integer(a & b));
+            interpreter.stack.push(Value::Integer(a & b));
             return;
         }
-        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(frame, a & b),
+        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(interpreter, a & b),
         (Value::BigInteger(a), Value::Integer(b)) | (Value::Integer(b), Value::BigInteger(a)) => {
-            demote!(frame, a & BigInt::from(b))
+            demote!(interpreter, a & BigInt::from(b))
         }
         _ => panic!("'{}': wrong types", SIGNATURE),
     }
@@ -435,21 +397,19 @@ fn bitand(interpreter: &mut Interpreter, _: &mut Universe) {
 fn bitxor(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#bitXor:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
 
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => {
-            frame.borrow_mut().stack.push(Value::Integer(a ^ b));
+            interpreter.stack.push(Value::Integer(a ^ b));
             return;
         }
-        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(frame, a ^ b),
+        (Value::BigInteger(a), Value::BigInteger(b)) => demote!(interpreter, a ^ b),
         (Value::BigInteger(a), Value::Integer(b)) | (Value::Integer(b), Value::BigInteger(a)) => {
-            demote!(frame, a ^ BigInt::from(b))
+            demote!(interpreter, a ^ BigInt::from(b))
         }
         _ => panic!("'{}': wrong types", SIGNATURE),
     }
@@ -458,45 +418,34 @@ fn bitxor(interpreter: &mut Interpreter, _: &mut Universe) {
 fn lt(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#<";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
 
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => {
-            frame.borrow_mut().stack.push(Value::Boolean(a < b));
+            interpreter.stack.push(Value::Boolean(a < b));
             return;
         }
         (Value::BigInteger(a), Value::BigInteger(b)) => {
-            frame.borrow_mut().stack.push(Value::Boolean(a < b));
+            interpreter.stack.push(Value::Boolean(a < b));
             return;
         }
         (Value::Double(a), Value::Double(b)) => {
-            frame.borrow_mut().stack.push(Value::Boolean(a < b));
+            interpreter.stack.push(Value::Boolean(a < b));
             return;
         }
         (Value::Integer(a), Value::Double(b)) | (Value::Double(b), Value::Integer(a)) => {
-            frame
-                .borrow_mut()
-                .stack
-                .push(Value::Boolean((a as f64) < b));
+            interpreter.stack.push(Value::Boolean((a as f64) < b));
             return;
         }
         (Value::BigInteger(a), Value::Integer(b)) => {
-            frame
-                .borrow_mut()
-                .stack
-                .push(Value::Boolean(a < BigInt::from(b)));
+            interpreter.stack.push(Value::Boolean(a < BigInt::from(b)));
             return;
         }
         (Value::Integer(a), Value::BigInteger(b)) => {
-            frame
-                .borrow_mut()
-                .stack
-                .push(Value::Boolean(b < BigInt::from(a)));
+            interpreter.stack.push(Value::Boolean(b < BigInt::from(a)));
             return;
         }
         (a, b) => panic!("'{}': wrong types ({:?} | {:?})", SIGNATURE, a, b),
@@ -506,35 +455,30 @@ fn lt(interpreter: &mut Interpreter, _: &mut Universe) {
 fn eq(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#=";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
 
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => {
-            frame.borrow_mut().stack.push(Value::Boolean(a == b));
+            interpreter.stack.push(Value::Boolean(a == b));
             return;
         }
         (Value::BigInteger(a), Value::BigInteger(b)) => {
-            frame.borrow_mut().stack.push(Value::Boolean(a == b));
+            interpreter.stack.push(Value::Boolean(a == b));
             return;
         }
         (Value::Double(a), Value::Double(b)) => {
-            frame.borrow_mut().stack.push(Value::Boolean(a == b));
+            interpreter.stack.push(Value::Boolean(a == b));
             return;
         }
         (Value::Integer(a), Value::Double(b)) | (Value::Double(b), Value::Integer(a)) => {
-            frame
-                .borrow_mut()
-                .stack
-                .push(Value::Boolean((a as f64) == b));
+            interpreter.stack.push(Value::Boolean((a as f64) == b));
             return;
         }
         _ => {
-            frame.borrow_mut().stack.push(Value::Boolean(false));
+            interpreter.stack.push(Value::Boolean(false));
             return;
         }
     }
@@ -543,9 +487,7 @@ fn eq(interpreter: &mut Interpreter, _: &mut Universe) {
 fn shift_left(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#<<";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         Value::Integer(b) => b,
     ]);
@@ -553,12 +495,12 @@ fn shift_left(interpreter: &mut Interpreter, _: &mut Universe) {
     match a {
         Value::Integer(a) => match a.checked_shl(b as u32) {
             Some(value) => {
-                frame.borrow_mut().stack.push(Value::Integer(value));
+                interpreter.stack.push(Value::Integer(value));
                 return;
             }
-            None => demote!(frame, BigInt::from(a) << (b as usize)),
+            None => demote!(interpreter, BigInt::from(a) << (b as usize)),
         },
-        Value::BigInteger(a) => demote!(frame, a << (b as usize)),
+        Value::BigInteger(a) => demote!(interpreter, a << (b as usize)),
         _ => panic!("'{}': wrong types", SIGNATURE),
     }
 }
@@ -566,9 +508,7 @@ fn shift_left(interpreter: &mut Interpreter, _: &mut Universe) {
 fn shift_right(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#>>";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         Value::Integer(b) => b,
     ]);
@@ -576,12 +516,12 @@ fn shift_right(interpreter: &mut Interpreter, _: &mut Universe) {
     match a {
         Value::Integer(a) => match a.checked_shr(b as u32) {
             Some(value) => {
-                frame.borrow_mut().stack.push(Value::Integer(value));
+                interpreter.stack.push(Value::Integer(value));
                 return;
             }
-            None => demote!(frame, BigInt::from(a) >> (b as usize)),
+            None => demote!(interpreter, BigInt::from(a) >> (b as usize)),
         },
-        Value::BigInteger(a) => demote!(frame, a >> (b as usize)),
+        Value::BigInteger(a) => demote!(interpreter, a >> (b as usize)),
         _ => panic!("'{}': wrong types", SIGNATURE),
     }
 }

--- a/som-interpreter-bc/src/primitives/method.rs
+++ b/som-interpreter-bc/src/primitives/method.rs
@@ -7,14 +7,12 @@ use crate::{expect_args, reverse};
 fn holder(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Method>>#holder";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         Value::Invokable(invokable) => invokable,
     ]);
 
     match invokable.holder().upgrade() {
-        Some(holder) => frame.borrow_mut().stack.push(Value::Class(holder)),
+        Some(holder) => interpreter.stack.push(Value::Class(holder)),
         None => panic!("'{}': method sholder has been collected", SIGNATURE),
     }
 }
@@ -22,22 +20,18 @@ fn holder(interpreter: &mut Interpreter, _: &mut Universe) {
 fn signature(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &str = "Method>>#signature";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         Value::Invokable(invokable) => invokable,
     ]);
 
     let sym = universe.intern_symbol(invokable.signature());
-    frame.borrow_mut().stack.push(Value::Symbol(sym))
+    interpreter.stack.push(Value::Symbol(sym))
 }
 
 fn invoke_on_with(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &str = "Method>>#invokeOn:with:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         Value::Invokable(invokable) => invokable,
         receiver => receiver,
         Value::Array(args) => args,

--- a/som-interpreter-bc/src/primitives/mod.rs
+++ b/som-interpreter-bc/src/primitives/mod.rs
@@ -29,11 +29,11 @@ pub type PrimitiveFn = fn(interpreter: &mut Interpreter, universe: &mut Universe
 
 #[macro_export]
 macro_rules! reverse {
-    ($signature:expr, $frame:expr, [], [ $( $ptrn:pat $( => $name:ident )? ),* $(,)? ]) => {
+    ($signature:expr, $interpreter:expr, [], [ $( $ptrn:pat $( => $name:ident )? ),* $(,)? ]) => {
         #[allow(unused_mut)]
         let ($($(mut $name,)?)*) = {
             $(#[allow(unreachable_patterns)]
-            $(let $name =)? match $frame.borrow_mut().stack.pop() {
+            $(let $name =)? match $interpreter.stack.pop() {
                 Some($ptrn) => {$($name)?},
                 Some(_) => panic!("'{}': wrong type", $signature),
                 None => panic!("'{}': missing argument", $signature),

--- a/som-interpreter-bc/src/primitives/object.rs
+++ b/som-interpreter-bc/src/primitives/object.rs
@@ -11,25 +11,17 @@ use crate::{expect_args, reverse};
 fn class(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &'static str = "Object>>#class";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         object => object,
     ]);
 
-    frame
-        .borrow_mut()
-        .stack
-        .push(Value::Class(object.class(universe)));
+    interpreter.stack.push(Value::Class(object.class(universe)));
 }
 
 fn object_size(interpreter: &mut Interpreter, _: &mut Universe) {
     const _: &'static str = "Object>>#objectSize";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    frame
-        .borrow_mut()
+    interpreter
         .stack
         .push(Value::Integer(std::mem::size_of::<Value>() as i64));
 }
@@ -37,9 +29,7 @@ fn object_size(interpreter: &mut Interpreter, _: &mut Universe) {
 fn hashcode(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &'static str = "Object>>#hashcode";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         value => value,
     ]);
 
@@ -47,28 +37,24 @@ fn hashcode(interpreter: &mut Interpreter, _: &mut Universe) {
     value.hash(&mut hasher);
     let hash = (hasher.finish() as i64).abs();
 
-    frame.borrow_mut().stack.push(Value::Integer(hash));
+    interpreter.stack.push(Value::Integer(hash));
 }
 
 fn eq(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &'static str = "Object>>#==";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         a => a,
         b => b,
     ]);
 
-    frame.borrow_mut().stack.push(Value::Boolean(a == b));
+    interpreter.stack.push(Value::Boolean(a == b));
 }
 
 fn perform(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &'static str = "Object>>#perform:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         object => object,
         Value::Symbol(sym) => sym,
     ]);
@@ -100,9 +86,7 @@ fn perform(interpreter: &mut Interpreter, universe: &mut Universe) {
 fn perform_with_arguments(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &'static str = "Object>>#perform:withArguments:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         object => object,
         Value::Symbol(sym) => sym,
         Value::Array(arr) => arr,
@@ -139,9 +123,7 @@ fn perform_with_arguments(interpreter: &mut Interpreter, universe: &mut Universe
 fn perform_in_super_class(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &'static str = "Object>>#perform:inSuperclass:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         object => object,
         Value::Symbol(sym) => sym,
         Value::Class(class) => class,
@@ -173,9 +155,7 @@ fn perform_in_super_class(interpreter: &mut Interpreter, universe: &mut Universe
 fn perform_with_arguments_in_super_class(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &'static str = "Object>>#perform:withArguments:inSuperclass:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         object => object,
         Value::Symbol(sym) => sym,
         Value::Array(arr) => arr,
@@ -213,9 +193,7 @@ fn perform_with_arguments_in_super_class(interpreter: &mut Interpreter, universe
 fn inst_var_at(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &'static str = "Object>>#instVarAt:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         object => object,
         Value::Integer(index) => index,
     ]);
@@ -227,15 +205,13 @@ fn inst_var_at(interpreter: &mut Interpreter, _: &mut Universe) {
 
     let local = object.lookup_local(index).unwrap_or(Value::Nil);
 
-    frame.borrow_mut().stack.push(local);
+    interpreter.stack.push(local);
 }
 
 fn inst_var_at_put(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &'static str = "Object>>#instVarAt:put:";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         object => object,
         Value::Integer(index) => index,
         value => value,
@@ -251,7 +227,7 @@ fn inst_var_at_put(interpreter: &mut Interpreter, _: &mut Universe) {
         .map(|_| value)
         .unwrap_or(Value::Nil);
 
-    frame.borrow_mut().stack.push(local);
+    interpreter.stack.push(local);
 }
 
 /// Search for a primitive matching the given signature.

--- a/som-interpreter-bc/src/primitives/symbol.rs
+++ b/som-interpreter-bc/src/primitives/symbol.rs
@@ -9,13 +9,11 @@ use crate::{expect_args, reverse};
 fn as_string(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &str = "Symbol>>#asString";
 
-    let frame = interpreter.current_frame().expect("no current frame");
-
-    expect_args!(SIGNATURE, frame, [
+    expect_args!(SIGNATURE, interpreter, [
         Value::Symbol(sym) => sym,
     ]);
 
-    frame.borrow_mut().stack.push(Value::String(Rc::new(
+    interpreter.stack.push(Value::String(Rc::new(
         universe.lookup_symbol(sym).to_string(),
     )));
 }


### PR DESCRIPTION
Currently, the bytecode interpreter uses different evaluation stacks on a per-frame basis, which incurs repeated and potentially unneeded reallocation costs.  

So, this PR circumvents this by using a single evaluation stack for the whole interpreter, that is shared by every frame, which takes care of not leaving any dummy values after their invocation except for their return value.

This PR only affects the bytecode interpreter (although it could also apply to the AST one).
