### PR TITLE
(opt): Reduced size and cloning costs of blocks

### DIFF
--- a/som-interpreter-bc/src/block.rs
+++ b/som-interpreter-bc/src/block.rs
@@ -12,16 +12,21 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::SOMRef;
 
+#[derive(Clone)]
+pub struct BlockInfo {
+    pub locals: Vec<Value>,
+    pub literals: Vec<Literal>,
+    pub body: Vec<Bytecode>,
+    pub nb_params: usize,
+    pub inline_cache: RefCell<Vec<Option<(*const Class, Rc<Method>)>>>,
+}
+
 /// Represents an executable block.
 #[derive(Clone)]
 pub struct Block {
     /// Reference to the captured stack frame.
     pub frame: Option<SOMRef<Frame>>,
-    pub locals: Vec<Value>,
-    pub literals: Vec<Literal>,
-    pub body: Vec<Bytecode>,
-    pub nb_params: usize,
-    pub inline_cache: Rc<RefCell<Vec<Option<(*const Class, Rc<Method>)>>>>,
+    pub blk_info: Rc<BlockInfo>,
 }
 
 impl Block {
@@ -37,7 +42,7 @@ impl Block {
 
     /// Retrieve the number of parameters this block accepts.
     pub fn nb_parameters(&self) -> usize {
-        self.nb_params
+        self.blk_info.nb_params
     }
 }
 

--- a/som-interpreter-bc/src/compiler.rs
+++ b/som-interpreter-bc/src/compiler.rs
@@ -11,7 +11,7 @@ use num_bigint::BigInt;
 use som_core::ast;
 use som_core::bytecode::Bytecode;
 
-use crate::block::Block;
+use crate::block::{Block, BlockInfo};
 use crate::class::{Class, MaybeWeak};
 use crate::interner::{Interned, Interner};
 use crate::method::{Method, MethodEnv, MethodKind};
@@ -459,15 +459,17 @@ fn compile_block(outer: &mut dyn GenCtxt, defn: &ast::Block) -> Option<Block> {
     let literals = ctxt.literals.into_iter().collect();
     let body = ctxt.body.unwrap_or_default();
     let nb_params = ctxt.args.len();
-    let inline_cache = Rc::new(RefCell::new(vec![None; body.len()]));
+    let inline_cache = RefCell::new(vec![None; body.len()]);
 
     let block = Block {
         frame,
-        locals,
-        literals,
-        body,
-        nb_params,
-        inline_cache,
+        blk_info: Rc::new(BlockInfo {
+            locals,
+            literals,
+            body,
+            nb_params,
+            inline_cache,
+        }),
     };
 
     // println!("(system) compiled block !");

--- a/som-interpreter-bc/src/frame.rs
+++ b/som-interpreter-bc/src/frame.rs
@@ -45,7 +45,7 @@ impl Frame {
     pub fn from_kind(kind: FrameKind) -> Self {
         match &kind {
             FrameKind::Block { block } => {
-                let locals = block.locals.iter().map(|_| Value::Nil).collect();
+                let locals = block.blk_info.locals.iter().map(|_| Value::Nil).collect();
                 Self {
                     kind,
                     locals,
@@ -113,7 +113,7 @@ impl Frame {
                 MethodKind::Primitive(_) => None,
                 MethodKind::NotImplemented(_) => None,
             },
-            FrameKind::Block { block, .. } => block.body.get(idx).copied(),
+            FrameKind::Block { block, .. } => block.blk_info.body.get(idx).copied(),
         }
     }
 
@@ -124,7 +124,7 @@ impl Frame {
 
     pub fn lookup_constant(&self, idx: usize) -> Option<Literal> {
         match self.kind() {
-            FrameKind::Block { block } => block.literals.get(idx).cloned(),
+            FrameKind::Block { block } => block.blk_info.literals.get(idx).cloned(),
             FrameKind::Method { method, .. } => match method.kind() {
                 MethodKind::Defined(env) => env.literals.get(idx).cloned(),
                 MethodKind::Primitive(_) => None,

--- a/som-interpreter-bc/src/hashcode.rs
+++ b/som-interpreter-bc/src/hashcode.rs
@@ -91,10 +91,10 @@ impl Hash for Instance {
 
 impl Hash for Block {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
-        self.literals.iter().for_each(|it| it.hash(hasher));
-        self.locals.iter().for_each(|it| it.hash(hasher));
-        self.nb_params.hash(hasher);
-        self.body.iter().for_each(|it| it.hash(hasher));
+        self.blk_info.literals.iter().for_each(|it| it.hash(hasher));
+        self.blk_info.locals.iter().for_each(|it| it.hash(hasher));
+        self.blk_info.nb_params.hash(hasher);
+        self.blk_info.body.iter().for_each(|it| it.hash(hasher));
     }
 }
 

--- a/som-interpreter-bc/src/interpreter.rs
+++ b/som-interpreter-bc/src/interpreter.rs
@@ -327,7 +327,7 @@ impl Interpreter {
         ) -> Option<Rc<Method>> {
             match frame.borrow().kind() {
                 FrameKind::Block { block } => {
-                    let mut inline_cache = block.inline_cache.borrow_mut();
+                    let mut inline_cache = block.blk_info.inline_cache.borrow_mut();
 
                     // SAFETY: this access is actually safe because the bytecode compiler
                     // makes sure the cache has as many entries as there are bytecode instructions,


### PR DESCRIPTION
This PR reduces the overall size of blocks and the cost of cloning one, which impacts the time it takes to instantiate a block (transforming a block definition to a usable SOM value), in hopes to improve performance.  

This PR only affects the bytecode interpreter.
