### PR TITLE
Fixed binary super sends

### DIFF
--- a/som-interpreter-ast/src/block.rs
+++ b/som-interpreter-ast/src/block.rs
@@ -23,7 +23,7 @@ impl Block {
             0 => universe.block1_class(),
             1 => universe.block2_class(),
             2 => universe.block3_class(),
-            _ => panic!("no support for blocks with more than 2 paramters"),
+            _ => panic!("no support for blocks with more than 2 parameters"),
         }
     }
 

--- a/som-interpreter-bc/src/compiler.rs
+++ b/som-interpreter-bc/src/compiler.rs
@@ -272,11 +272,19 @@ impl MethodCodegen for ast::Expression {
                 Some(())
             }
             ast::Expression::BinaryOp(message) => {
+                let super_send = match message.lhs.as_ref() {
+                    ast::Expression::Reference(value) if value == "super" => true,
+                    _ => false,
+                };
                 message.lhs.codegen(ctxt)?;
                 message.rhs.codegen(ctxt)?;
                 let sym = ctxt.intern_symbol(message.op.as_str());
                 let idx = ctxt.push_literal(Literal::Symbol(sym));
-                ctxt.push_instr(Bytecode::Send(idx as u8));
+                if super_send {
+                    ctxt.push_instr(Bytecode::SuperSend(idx as u8));
+                } else {
+                    ctxt.push_instr(Bytecode::Send(idx as u8));
+                }
                 Some(())
             }
             ast::Expression::Exit(expr) => {


### PR DESCRIPTION
This PR fixes a bug that caused binary operators to behave incorrectly when used with `super` as its left-hand side.  
These cases should evaluate to a message super-send instead of a normal message send, as it did before.  

Here is an example of such a case:

```smalltalk
" SuperTest.som "
SuperTest = (
    + other = (
        ^ 53
    )
)

" Test.som "
Test = SuperTest (
    + other = (
        ^ 42
    )

    run = (
        (self + 14) println.
        (super + 14) println.
    )
)
```

The expected output is:
```txt
42
53
```
But before this PR, the output was:
```txt
42
42
```