### PR TITLE
Updated core-lib + Implemented latest primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
+# Rust's folder for its build artifacts.
 /target
-.vscode
+
+# SOM files at the project root are considered test files.
 /*.som
+
+# File indexing cache file for macOS.
 .DS_Store
+
+# Folders for workspace-specific configurations of code editors.
+/.vscode
+/.nova
+/.idea

--- a/som-interpreter-ast/src/invokable.rs
+++ b/som-interpreter-ast/src/invokable.rs
@@ -53,9 +53,15 @@ impl Invoke for Method {
                         )
                     }
                 };
-                universe.with_frame(FrameKind::Method { holder, self_value }, |universe| {
-                    method.invoke(universe, params)
-                })
+                let signature = universe.intern_symbol(&self.signature);
+                universe.with_frame(
+                    FrameKind::Method {
+                        holder,
+                        signature,
+                        self_value,
+                    },
+                    |universe| method.invoke(universe, params),
+                )
             }
             MethodKind::Primitive(func) => func(universe, args),
             MethodKind::NotImplemented(name) => {

--- a/som-interpreter-ast/src/primitives/integer.rs
+++ b/som-interpreter-ast/src/primitives/integer.rs
@@ -27,6 +27,7 @@ pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
     ("bitXor:", self::bitxor, true),
     ("sqrt", self::sqrt, true),
     ("asString", self::as_string, true),
+    ("asDouble", self::as_double, true),
     ("atRandom", self::at_random, true),
     ("as32BitSignedValue", self::as_32bit_signed_value, true),
     ("as32BitUnsignedValue", self::as_32bit_unsigned_value, true),
@@ -81,6 +82,26 @@ fn as_string(_: &mut Universe, args: Vec<Value>) -> Return {
     };
 
     Return::Local(Value::String(Rc::new(value)))
+}
+
+fn as_double(_: &mut Universe, args: Vec<Value>) -> Return {
+    const SIGNATURE: &str = "Integer>>#asDouble";
+
+    expect_args!(SIGNATURE, args, [
+        value => value,
+    ]);
+
+    match value {
+        Value::Integer(value) => Return::Local(Value::Double(value as f64)),
+        Value::BigInteger(value) => match value.to_i64() {
+            Some(value) => Return::Local(Value::Double(value as f64)),
+            None => Return::Exception(format!(
+                "'{}': `Integer` too big to be converted to `Double`",
+                SIGNATURE
+            )),
+        },
+        _ => Return::Exception(format!("'{}': wrong types", SIGNATURE)),
+    }
 }
 
 fn at_random(_: &mut Universe, args: Vec<Value>) -> Return {

--- a/som-interpreter-ast/src/primitives/string.rs
+++ b/som-interpreter-ast/src/primitives/string.rs
@@ -165,7 +165,7 @@ fn eq(universe: &mut Universe, args: Vec<Value>) -> Return {
         s1 => s1,
         s2 => s2,
     ]);
-    
+
     let s1 = match s1 {
         Value::String(ref s1) => s1.as_str(),
         Value::Symbol(s1) => universe.lookup_symbol(s1),
@@ -179,7 +179,7 @@ fn eq(universe: &mut Universe, args: Vec<Value>) -> Return {
         Value::Symbol(s2) => universe.lookup_symbol(s2),
         _ => {
             return Return::Local(Value::Boolean(false));
-        },
+        }
     };
 
     Return::Local(Value::Boolean(s1 == s2))

--- a/som-interpreter-ast/src/primitives/string.rs
+++ b/som-interpreter-ast/src/primitives/string.rs
@@ -158,13 +158,29 @@ fn as_symbol(universe: &mut Universe, args: Vec<Value>) -> Return {
     }
 }
 
-fn eq(_: &mut Universe, args: Vec<Value>) -> Return {
+fn eq(universe: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "String>>#=";
 
     expect_args!(SIGNATURE, args, [
         s1 => s1,
         s2 => s2,
     ]);
+    
+    let s1 = match s1 {
+        Value::String(ref s1) => s1.as_str(),
+        Value::Symbol(s1) => universe.lookup_symbol(s1),
+        _ => {
+            return Return::Local(Value::Boolean(false));
+        }
+    };
+
+    let s2 = match s2 {
+        Value::String(ref s2) => s2.as_str(),
+        Value::Symbol(s2) => universe.lookup_symbol(s2),
+        _ => {
+            return Return::Local(Value::Boolean(false));
+        },
+    };
 
     Return::Local(Value::Boolean(s1 == s2))
 }

--- a/som-interpreter-ast/src/primitives/symbol.rs
+++ b/som-interpreter-ast/src/primitives/symbol.rs
@@ -7,7 +7,7 @@ use crate::universe::Universe;
 use crate::value::Value;
 
 pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] =
-    &[("asString", self::as_string, true)];
+    &[("asString", self::as_string, true), ("=", self::eq, false)];
 pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
 fn as_string(universe: &mut Universe, args: Vec<Value>) -> Return {
@@ -20,6 +20,17 @@ fn as_string(universe: &mut Universe, args: Vec<Value>) -> Return {
     Return::Local(Value::String(Rc::new(
         universe.lookup_symbol(sym).to_string(),
     )))
+}
+
+fn eq(_: &mut Universe, args: Vec<Value>) -> Return {
+    const SIGNATURE: &str = "Symbol>>#=";
+
+    expect_args!(SIGNATURE, args, [
+        sym @ Value::Symbol(_) => sym,
+        other => other,
+    ]);
+
+    Return::Local(Value::Boolean(sym == other))
 }
 
 /// Search for an instance primitive matching the given signature.

--- a/som-interpreter-ast/src/primitives/system.rs
+++ b/som-interpreter-ast/src/primitives/system.rs
@@ -1,14 +1,20 @@
 use std::convert::TryFrom;
+use std::fs;
+use std::rc::Rc;
 
 use crate::expect_args;
+use crate::frame::FrameKind;
 use crate::invokable::Return;
 use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::value::Value;
 
 pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("loadFile:", self::load_file, true),
     ("printString:", self::print_string, true),
     ("printNewline", self::print_newline, true),
+    ("errorPrint:", self::error_print, true),
+    ("errorPrintln:", self::error_println, true),
     ("load:", self::load, true),
     ("ticks", self::ticks, true),
     ("time", self::time, true),
@@ -16,8 +22,30 @@ pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
     ("exit:", self::exit, true),
     ("global:", self::global, true),
     ("global:put:", self::global_put, true),
+    ("hasGlobal:", self::has_global, true),
+    ("printStackTrace", self::print_stack_trace, true),
 ];
 pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
+fn load_file(universe: &mut Universe, args: Vec<Value>) -> Return {
+    const SIGNATURE: &str = "System>>#loadFile:";
+
+    expect_args!(SIGNATURE, args, [
+        Value::System,
+        value => value,
+    ]);
+
+    let path = match value {
+        Value::String(ref string) => string,
+        Value::Symbol(sym) => universe.lookup_symbol(sym),
+        _ => return Return::Exception(format!("'{}': wrong type", SIGNATURE)),
+    };
+
+    match fs::read_to_string(path) {
+        Ok(value) => Return::Local(Value::String(Rc::new(value))),
+        Err(_) => Return::Local(Value::Nil),
+    }
+}
 
 fn print_string(universe: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "System>>#printString:";
@@ -46,6 +74,42 @@ fn print_newline(_: &mut Universe, args: Vec<Value>) -> Return {
     Return::Local(Value::Nil)
 }
 
+fn error_print(universe: &mut Universe, args: Vec<Value>) -> Return {
+    const SIGNATURE: &str = "System>>#errorPrint:";
+
+    expect_args!(SIGNATURE, args, [
+        Value::System,
+        value => value,
+    ]);
+
+    let string = match value {
+        Value::String(ref string) => string,
+        Value::Symbol(sym) => universe.lookup_symbol(sym),
+        _ => return Return::Exception(format!("'{}': wrong type", SIGNATURE)),
+    };
+
+    eprint!("{}", string);
+    Return::Local(Value::System)
+}
+
+fn error_println(universe: &mut Universe, args: Vec<Value>) -> Return {
+    const SIGNATURE: &str = "System>>#errorPrintln:";
+
+    expect_args!(SIGNATURE, args, [
+        Value::System,
+        value => value,
+    ]);
+
+    let string = match value {
+        Value::String(ref string) => string,
+        Value::Symbol(sym) => universe.lookup_symbol(sym),
+        _ => return Return::Exception(format!("'{}': wrong type", SIGNATURE)),
+    };
+
+    eprintln!("{}", string);
+    Return::Local(Value::System)
+}
+
 fn load(universe: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "System>>#load:";
 
@@ -59,6 +123,18 @@ fn load(universe: &mut Universe, args: Vec<Value>) -> Return {
         Ok(class) => Return::Local(Value::Class(class)),
         Err(err) => Return::Exception(format!("'{}': {}", SIGNATURE, err)),
     }
+}
+
+fn has_global(universe: &mut Universe, args: Vec<Value>) -> Return {
+    const SIGNATURE: &str = "System>>#hasGlobal:";
+
+    expect_args!(SIGNATURE, args, [
+        Value::System,
+        Value::Symbol(sym) => sym,
+    ]);
+
+    let symbol = universe.lookup_symbol(sym);
+    Return::Local(Value::Boolean(universe.has_global(symbol)))
 }
 
 fn global(universe: &mut Universe, args: Vec<Value>) -> Return {
@@ -121,6 +197,25 @@ fn time(universe: &mut Universe, args: Vec<Value>) -> Return {
         Ok(micros) => Return::Local(Value::Integer(micros)),
         Err(err) => Return::Exception(format!("'{}': {}", SIGNATURE, err)),
     }
+}
+
+fn print_stack_trace(universe: &mut Universe, args: Vec<Value>) -> Return {
+    const SIGNATURE: &str = "System>>#printStackTrace";
+
+    expect_args!(SIGNATURE, args, [Value::System]);
+
+    for frame in &universe.frames {
+        let class = frame.borrow().get_method_holder();
+        let signature = frame.borrow().get_method_signature();
+        let signature = universe.lookup_symbol(signature);
+        let block = match frame.borrow().kind() {
+            FrameKind::Block { .. } => "$block",
+            _ => "",
+        };
+        println!("{}>>#{}{}", class.borrow().name(), signature, block);
+    }
+
+    Return::Local(Value::Boolean(true))
 }
 
 fn full_gc(_: &mut Universe, args: Vec<Value>) -> Return {

--- a/som-interpreter-ast/src/shell.rs
+++ b/som-interpreter-ast/src/shell.rs
@@ -23,6 +23,7 @@ pub fn interactive(universe: &mut Universe, verbose: bool) -> Result<(), Error> 
     let mut counter = 0;
     let mut line = String::new();
     let mut last_value = Value::Nil;
+    let signature = universe.intern_symbol("run:");
     loop {
         write!(&mut stdout, "({}) SOM Shell | ", counter)?;
         stdout.flush()?;
@@ -75,6 +76,7 @@ pub fn interactive(universe: &mut Universe, verbose: bool) -> Result<(), Error> 
 
         let start = Instant::now();
         let kind = FrameKind::Method {
+            signature,
             holder: universe.system_class(),
             self_value: Value::System,
         };

--- a/som-interpreter-ast/src/universe.rs
+++ b/som-interpreter-ast/src/universe.rs
@@ -508,6 +508,12 @@ impl Universe {
         }
     }
 
+    /// Returns whether a global binding of the specified name exists.
+    pub fn has_global(&self, name: impl AsRef<str>) -> bool {
+        let name = name.as_ref();
+        self.globals.contains_key(name)
+    }
+
     /// Search for a global binding.
     pub fn lookup_global(&self, name: impl AsRef<str>) -> Option<Value> {
         let name = name.as_ref();

--- a/som-interpreter-ast/src/value.rs
+++ b/som-interpreter-ast/src/value.rs
@@ -146,9 +146,9 @@ impl PartialEq for Value {
             (Self::BigInteger(a), Self::Integer(b)) | (Self::Integer(b), Self::BigInteger(a)) => {
                 a.eq(&BigInt::from(*b))
             }
-            (Self::String(a), Self::String(b)) => a.eq(b),
             (Self::Symbol(a), Self::Symbol(b)) => a.eq(b),
-            (Self::Array(a), Self::Array(b)) => a.eq(b),
+            (Self::String(a), Self::String(b)) => Rc::ptr_eq(a, b),
+            (Self::Array(a), Self::Array(b)) => Rc::ptr_eq(a, b),
             (Self::Instance(a), Self::Instance(b)) => Rc::ptr_eq(a, b),
             (Self::Class(a), Self::Class(b)) => Rc::ptr_eq(a, b),
             (Self::Block(a), Self::Block(b)) => Rc::ptr_eq(a, b),

--- a/som-interpreter-bc/src/frame.rs
+++ b/som-interpreter-bc/src/frame.rs
@@ -97,6 +97,14 @@ impl Frame {
         }
     }
 
+    /// Get the current method itself.
+    pub fn get_method(&self) -> Rc<Method> {
+        match &self.kind {
+            FrameKind::Method { method, .. } => method.clone(),
+            FrameKind::Block { block, .. } => block.frame.as_ref().unwrap().borrow().get_method(),
+        }
+    }
+
     /// Get the bytecode at the specified index for the current method.
     pub fn get_bytecode(&self, idx: usize) -> Option<Bytecode> {
         match &self.kind {

--- a/som-interpreter-bc/src/primitives/integer.rs
+++ b/som-interpreter-bc/src/primitives/integer.rs
@@ -27,6 +27,7 @@ pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
     ("bitXor:", self::bitxor, true),
     ("sqrt", self::sqrt, true),
     ("asString", self::as_string, true),
+    ("asDouble", self::as_double, true),
     ("atRandom", self::at_random, true),
     ("as32BitSignedValue", self::as_32bit_signed_value, true),
     ("as32BitUnsignedValue", self::as_32bit_unsigned_value, true),
@@ -87,6 +88,28 @@ fn as_string(interpreter: &mut Interpreter, _: &mut Universe) {
         interpreter.stack.push(Value::String(Rc::new(value)));
         return;
     }
+}
+
+fn as_double(interpreter: &mut Interpreter, _: &mut Universe) {
+    const SIGNATURE: &str = "Integer>>#asDouble";
+
+    expect_args!(SIGNATURE, interpreter, [
+        value => value,
+    ]);
+
+    let value = match value {
+        Value::Integer(value) => Value::Double(value as f64),
+        Value::BigInteger(value) => match value.to_i64() {
+            Some(value) => Value::Double(value as f64),
+            None => panic!(
+                "'{}': `Integer` too big to be converted to `Double`",
+                SIGNATURE
+            ),
+        },
+        _ => panic!("'{}': wrong types", SIGNATURE),
+    };
+
+    interpreter.stack.push(value);
 }
 
 fn at_random(interpreter: &mut Interpreter, _: &mut Universe) {

--- a/som-interpreter-bc/src/primitives/string.rs
+++ b/som-interpreter-bc/src/primitives/string.rs
@@ -176,7 +176,7 @@ fn eq(interpreter: &mut Interpreter, universe: &mut Universe) {
         _ => {
             interpreter.stack.push(Value::Boolean(false));
             return;
-        },
+        }
     };
 
     let s2 = match s2 {
@@ -185,7 +185,7 @@ fn eq(interpreter: &mut Interpreter, universe: &mut Universe) {
         _ => {
             interpreter.stack.push(Value::Boolean(false));
             return;
-        },
+        }
     };
 
     interpreter.stack.push(Value::Boolean(s1 == s2))

--- a/som-interpreter-bc/src/primitives/string.rs
+++ b/som-interpreter-bc/src/primitives/string.rs
@@ -162,13 +162,31 @@ fn as_symbol(interpreter: &mut Interpreter, universe: &mut Universe) {
     }
 }
 
-fn eq(interpreter: &mut Interpreter, _: &mut Universe) {
+fn eq(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &str = "String>>#=";
 
     expect_args!(SIGNATURE, interpreter, [
         s1 => s1,
         s2 => s2,
     ]);
+
+    let s1 = match s1 {
+        Value::String(ref s1) => s1.as_str(),
+        Value::Symbol(s1) => universe.lookup_symbol(s1),
+        _ => {
+            interpreter.stack.push(Value::Boolean(false));
+            return;
+        },
+    };
+
+    let s2 = match s2 {
+        Value::String(ref s2) => s2.as_str(),
+        Value::Symbol(s2) => universe.lookup_symbol(s2),
+        _ => {
+            interpreter.stack.push(Value::Boolean(false));
+            return;
+        },
+    };
 
     interpreter.stack.push(Value::Boolean(s1 == s2))
 }

--- a/som-interpreter-bc/src/primitives/symbol.rs
+++ b/som-interpreter-bc/src/primitives/symbol.rs
@@ -7,7 +7,7 @@ use crate::value::Value;
 use crate::{expect_args, reverse};
 
 pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] =
-    &[("asString", self::as_string, true)];
+    &[("asString", self::as_string, true), ("=", self::eq, false)];
 pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
 fn as_string(interpreter: &mut Interpreter, universe: &mut Universe) {
@@ -20,6 +20,17 @@ fn as_string(interpreter: &mut Interpreter, universe: &mut Universe) {
     interpreter.stack.push(Value::String(Rc::new(
         universe.lookup_symbol(sym).to_string(),
     )));
+}
+
+fn eq(interpreter: &mut Interpreter, _: &mut Universe) {
+    const SIGNATURE: &str = "Symbol>>#=";
+
+    expect_args!(SIGNATURE, interpreter, [
+        sym @ Value::Symbol(_) => sym,
+        other => other,
+    ]);
+
+    interpreter.stack.push(Value::Boolean(sym == other));
 }
 
 /// Search for an instance primitive matching the given signature.

--- a/som-interpreter-bc/src/primitives/system.rs
+++ b/som-interpreter-bc/src/primitives/system.rs
@@ -1,5 +1,8 @@
 use std::convert::TryFrom;
+use std::fs;
+use std::rc::Rc;
 
+use crate::frame::FrameKind;
 use crate::interpreter::Interpreter;
 use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
@@ -7,8 +10,11 @@ use crate::value::Value;
 use crate::{expect_args, reverse};
 
 pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("loadFile:", self::load_file, true),
     ("printString:", self::print_string, true),
     ("printNewline", self::print_newline, true),
+    ("errorPrint:", self::error_print, true),
+    ("errorPrintln:", self::error_println, true),
     ("load:", self::load, true),
     ("ticks", self::ticks, true),
     ("time", self::time, true),
@@ -16,8 +22,32 @@ pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
     ("exit:", self::exit, true),
     ("global:", self::global, true),
     ("global:put:", self::global_put, true),
+    ("hasGlobal:", self::has_global, true),
+    ("printStackTrace", self::print_stack_trace, true),
 ];
 pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
+fn load_file(interpreter: &mut Interpreter, universe: &mut Universe) {
+    const SIGNATURE: &str = "System>>#loadFile:";
+
+    expect_args!(SIGNATURE, interpreter, [
+        Value::System,
+        value => value,
+    ]);
+
+    let path = match value {
+        Value::String(ref string) => string,
+        Value::Symbol(sym) => universe.lookup_symbol(sym),
+        _ => panic!("'{}': wrong type", SIGNATURE),
+    };
+
+    let value = match fs::read_to_string(path) {
+        Ok(value) => Value::String(Rc::new(value)),
+        Err(_) => Value::Nil,
+    };
+
+    interpreter.stack.push(value);
+}
 
 fn print_string(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &str = "System>>#printString:";
@@ -45,7 +75,43 @@ fn print_newline(interpreter: &mut Interpreter, _: &mut Universe) {
     expect_args!(SIGNATURE, interpreter, [Value::System]);
 
     println!();
-    interpreter.stack.push(Value::Nil)
+    interpreter.stack.push(Value::Nil);
+}
+
+fn error_print(interpreter: &mut Interpreter, universe: &mut Universe) {
+    const SIGNATURE: &str = "System>>#errorPrint:";
+
+    expect_args!(SIGNATURE, interpreter, [
+        Value::System,
+        value => value,
+    ]);
+
+    let string = match value {
+        Value::String(ref string) => string,
+        Value::Symbol(sym) => universe.lookup_symbol(sym),
+        _ => panic!("'{}': wrong type", SIGNATURE),
+    };
+
+    eprint!("{}", string);
+    interpreter.stack.push(Value::System);
+}
+
+fn error_println(interpreter: &mut Interpreter, universe: &mut Universe) {
+    const SIGNATURE: &str = "System>>#errorPrintln:";
+
+    expect_args!(SIGNATURE, interpreter, [
+        Value::System,
+        value => value,
+    ]);
+
+    let string = match value {
+        Value::String(ref string) => string,
+        Value::Symbol(sym) => universe.lookup_symbol(sym),
+        _ => panic!("'{}': wrong type", SIGNATURE),
+    };
+
+    eprintln!("{}", string);
+    interpreter.stack.push(Value::System);
 }
 
 fn load(interpreter: &mut Interpreter, universe: &mut Universe) {
@@ -63,6 +129,19 @@ fn load(interpreter: &mut Interpreter, universe: &mut Universe) {
     }
 }
 
+fn has_global(interpreter: &mut Interpreter, universe: &mut Universe) {
+    const SIGNATURE: &str = "System>>#hasGlobal:";
+
+    expect_args!(SIGNATURE, interpreter, [
+        Value::System,
+        Value::Symbol(sym) => sym,
+    ]);
+
+    let value = Value::Boolean(universe.has_global(sym));
+
+    interpreter.stack.push(value);
+}
+
 fn global(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &str = "System>>#global:";
 
@@ -71,9 +150,9 @@ fn global(interpreter: &mut Interpreter, universe: &mut Universe) {
         Value::Symbol(sym) => sym,
     ]);
 
-    interpreter
-        .stack
-        .push(universe.lookup_global(sym).unwrap_or(Value::Nil))
+    let value = universe.lookup_global(sym).unwrap_or(Value::Nil);
+
+    interpreter.stack.push(value);
 }
 
 fn global_put(interpreter: &mut Interpreter, universe: &mut Universe) {
@@ -86,7 +165,7 @@ fn global_put(interpreter: &mut Interpreter, universe: &mut Universe) {
     ]);
 
     universe.assign_global(sym, value.clone());
-    interpreter.stack.push(value)
+    interpreter.stack.push(value);
 }
 
 fn exit(interpreter: &mut Interpreter, _: &mut Universe) {
@@ -125,13 +204,38 @@ fn time(interpreter: &mut Interpreter, _: &mut Universe) {
     }
 }
 
+fn print_stack_trace(interpreter: &mut Interpreter, _: &mut Universe) {
+    const SIGNATURE: &str = "System>>#printStackTrace";
+
+    expect_args!(SIGNATURE, interpreter, [Value::System]);
+
+    for frame in &interpreter.frames {
+        let class = frame.borrow().get_method_holder();
+        let method = frame.borrow().get_method();
+        let bytecode_idx = frame.borrow().bytecode_idx;
+        let block = match frame.borrow().kind() {
+            FrameKind::Block { .. } => "$block",
+            _ => "",
+        };
+        println!(
+            "{}>>#{}{} @bi: {}",
+            class.borrow().name(),
+            method.signature(),
+            block,
+            bytecode_idx
+        );
+    }
+
+    interpreter.stack.push(Value::Boolean(true));
+}
+
 fn full_gc(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "System>>#fullGC";
 
     expect_args!(SIGNATURE, interpreter, [Value::System]);
 
     // We don't do any garbage collection at all, so we return false.
-    interpreter.stack.push(Value::Boolean(false))
+    interpreter.stack.push(Value::Boolean(false));
 }
 
 /// Search for an instance primitive matching the given signature.

--- a/som-interpreter-bc/src/universe.rs
+++ b/som-interpreter-bc/src/universe.rs
@@ -480,6 +480,10 @@ impl Universe {
         self.interner.intern(symbol)
     }
 
+    pub fn has_global(&self, idx: Interned) -> bool {
+        self.globals.contains_key(&idx)
+    }
+
     /// Lookup a symbol.
     pub fn lookup_symbol(&self, symbol: Interned) -> &str {
         self.interner.lookup(symbol)

--- a/som-interpreter-bc/src/value.rs
+++ b/som-interpreter-bc/src/value.rs
@@ -142,9 +142,9 @@ impl PartialEq for Value {
             (Self::BigInteger(a), Self::Integer(b)) | (Self::Integer(b), Self::BigInteger(a)) => {
                 a.eq(&BigInt::from(*b))
             }
-            (Self::String(a), Self::String(b)) => a.eq(b),
             (Self::Symbol(a), Self::Symbol(b)) => a.eq(b),
-            (Self::Array(a), Self::Array(b)) => a.eq(b),
+            (Self::String(a), Self::String(b)) => Rc::ptr_eq(a, b),
+            (Self::Array(a), Self::Array(b)) => Rc::ptr_eq(a, b),
             (Self::Instance(a), Self::Instance(b)) => Rc::ptr_eq(a, b),
             (Self::Class(a), Self::Class(b)) => Rc::ptr_eq(a, b),
             (Self::Block(a), Self::Block(b)) => Rc::ptr_eq(a, b),

--- a/som-interpreter-bc/tests/basic_interpreter_tests.rs
+++ b/som-interpreter-bc/tests/basic_interpreter_tests.rs
@@ -39,6 +39,9 @@ fn basic_interpreter_tests() {
         ("Blocks testArg2", Value::Integer(77)),
         ("Blocks testArgAndLocal", Value::Integer(8)),
         ("Blocks testArgAndContext", Value::Integer(8)),
+        ("Blocks testEmptyZeroArg", Value::Integer(1)),
+        ("Blocks testEmptyOneArg", Value::Integer(1)),
+        ("Blocks testEmptyTwoArg", Value::Integer(1)),
         ("Return testReturnSelf", return_class.clone()),
         ("Return testReturnSelfImplicitly", return_class.clone()),
         ("Return testNoReturnReturnsSelf", return_class.clone()),
@@ -52,6 +55,22 @@ fn basic_interpreter_tests() {
         (
             "CompilerSimplification testReturnConstantSymbol",
             Value::Symbol(universe.intern_symbol("constant")),
+        ),
+        (
+            "IfTrueIfFalse testIfTrueTrueResult",
+            Value::Class(universe.integer_class()),
+        ),
+        (
+            "IfTrueIfFalse testIfTrueFalseResult",
+            Value::Class(universe.nil_class()),
+        ),
+        (
+            "IfTrueIfFalse testIfFalseTrueResult",
+            Value::Class(universe.nil_class()),
+        ),
+        (
+            "IfTrueIfFalse testIfFalseFalseResult",
+            Value::Class(universe.integer_class()),
         ),
         (
             "CompilerSimplification testReturnConstantInt",
@@ -94,8 +113,18 @@ fn basic_interpreter_tests() {
             "BlockInlining testOneLevelInliningWithLocalShadowFalse",
             Value::Integer(1),
         ),
+        (
+            "BlockInlining testShadowDoesntStoreWrongLocal",
+            Value::Integer(33),
+        ),
+        (
+            "BlockInlining testShadowDoesntReadUnrelated",
+            Value::Class(universe.nil_class()),
+        ),
         ("BlockInlining testBlockNestedInIfTrue", Value::Integer(2)),
         ("BlockInlining testBlockNestedInIfFalse", Value::Integer(42)),
+        ("BlockInlining testStackDisciplineTrue", Value::Integer(1)),
+        ("BlockInlining testStackDisciplineFalse", Value::Integer(2)),
         (
             "BlockInlining testDeepNestedInlinedIfTrue",
             Value::Integer(3),
@@ -119,8 +148,13 @@ fn basic_interpreter_tests() {
         ("ObjectCreation test", Value::Integer(1000000)),
         ("Regressions testSymbolEquality", Value::Integer(1)),
         ("Regressions testSymbolReferenceEquality", Value::Integer(1)),
+        ("Regressions testUninitializedLocal", Value::Integer(1)),
+        (
+            "Regressions testUninitializedLocalInBlock",
+            Value::Integer(1),
+        ),
         ("BinaryOperation test", Value::Integer(3 + 8)),
-        ("NumberOfTests numberOfTests", Value::Integer(52)),
+        ("NumberOfTests numberOfTests", Value::Integer(65)),
     ];
 
     for (counter, (expr, expected)) in tests.iter().enumerate() {


### PR DESCRIPTION
This PR updates the core-lib submodule to the latest commit on its master branch.  
This PR also includes implementations for all of the latest primitives added since September 2020, for both interpreters.  

The implemented primitives are:

- `Integer>>#asDouble`
- `System>>#loadFile:`
- `System>>#hasGlobal:`
- `System>>#errorPrint:`
- `System>>#errorPrintln:`
- `System>>#printStackTrace`

**Depends on #22.**