### PR TITLE
Fixed `Integer>>#<` primitive

### DIFF
--- a/som-interpreter-ast/src/primitives/integer.rs
+++ b/som-interpreter-ast/src/primitives/integer.rs
@@ -353,7 +353,7 @@ fn lt(_: &mut Universe, args: Vec<Value>) -> Return {
             Return::Local(Value::Boolean(a < BigInt::from(b)))
         }
         (Value::Integer(a), Value::BigInteger(b)) => {
-            Return::Local(Value::Boolean(b < BigInt::from(a)))
+            Return::Local(Value::Boolean(BigInt::from(a) < b))
         }
         (a, b) => {
             return Return::Exception(format!("'{}': wrong types ({:?} | {:?})", SIGNATURE, a, b))

--- a/som-interpreter-bc/src/primitives/integer.rs
+++ b/som-interpreter-bc/src/primitives/integer.rs
@@ -445,7 +445,7 @@ fn lt(interpreter: &mut Interpreter, _: &mut Universe) {
             return;
         }
         (Value::Integer(a), Value::BigInteger(b)) => {
-            interpreter.stack.push(Value::Boolean(b < BigInt::from(a)));
+            interpreter.stack.push(Value::Boolean(BigInt::from(a) < b));
             return;
         }
         (a, b) => panic!("'{}': wrong types ({:?} | {:?})", SIGNATURE, a, b),


### PR DESCRIPTION
This PR fixes a bug in the implementation of the `Integer>>#<` primitive.  
