### PR TITLE
Fixed many issues within `Integer` primitives

### DIFF
--- a/som-interpreter-ast/src/primitives/double.rs
+++ b/som-interpreter-ast/src/primitives/double.rs
@@ -1,5 +1,7 @@
 use std::rc::Rc;
 
+use num_traits::ToPrimitive;
+
 use crate::expect_args;
 use crate::invokable::Return;
 use crate::primitives::PrimitiveFn;
@@ -10,6 +12,15 @@ macro_rules! promote {
     ($signature:expr, $value:expr) => {
         match $value {
             Value::Integer(value) => value as f64,
+            Value::BigInteger(value) => match value.to_f64() {
+                Some(value) => value,
+                None => {
+                    return Return::Exception(format!(
+                        "'{}': `Integer` too big to be converted to `Double`",
+                        $signature
+                    ))
+                }
+            },
             Value::Double(value) => value,
             _ => {
                 return Return::Exception(format!(

--- a/som-interpreter-bc/src/primitives/double.rs
+++ b/som-interpreter-bc/src/primitives/double.rs
@@ -1,5 +1,7 @@
 use std::rc::Rc;
 
+use num_traits::ToPrimitive;
+
 use crate::interpreter::Interpreter;
 use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
@@ -10,6 +12,15 @@ macro_rules! promote {
     ($signature:expr, $value:expr) => {
         match $value {
             Value::Integer(value) => value as f64,
+            Value::BigInteger(value) => match value.to_f64() {
+                Some(value) => value,
+                None => {
+                    panic!(
+                        "'{}': `Integer` too big to be converted to `Double`",
+                        $signature
+                    )
+                }
+            },
             Value::Double(value) => value,
             _ => panic!(
                 "'{}': wrong type (expected `integer` or `double`)",


### PR DESCRIPTION
This PR fixes the following issues, related to `Integer` primitives:

- Some primitives did not work properly when used with `Double` and `BigInteger`.
- Some non-commutative primitives (like `<`, `-`, and `/`) had their operands reversed in some cases, depending on which input types were encountered.