### PR TITLE
Added ability to install non-standard primitives

### DIFF
--- a/som-interpreter-ast/src/method.rs
+++ b/som-interpreter-ast/src/method.rs
@@ -1,7 +1,6 @@
 use som_core::ast;
 
 use crate::class::Class;
-use crate::primitives;
 use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::{SOMRef, SOMWeakRef};
@@ -18,42 +17,6 @@ pub enum MethodKind {
 }
 
 impl MethodKind {
-    /// Return the interpreter primitive matching a given class name and signature.
-    pub fn primitive_from_signature(
-        class_name: impl AsRef<str>,
-        signature: impl AsRef<str>,
-    ) -> Self {
-        let class_name = class_name.as_ref();
-        let signature = signature.as_ref();
-        let primitive = match class_name {
-            "Object" => primitives::object::get_primitive(signature),
-            "Class" => primitives::class::get_primitive(signature),
-            "Integer" => primitives::integer::get_primitive(signature),
-            "Double" => primitives::double::get_primitive(signature),
-            "Array" => primitives::array::get_primitive(signature),
-            "String" => primitives::string::get_primitive(signature),
-            "Symbol" => primitives::symbol::get_primitive(signature),
-            "System" => primitives::system::get_primitive(signature),
-            "Method" => primitives::method::get_primitive(signature),
-            "Primitive" => primitives::method::get_primitive(signature),
-            "Block" => primitives::block1::get_primitive(signature),
-            "Block1" => primitives::block1::get_primitive(signature),
-            "Block2" => primitives::block2::get_primitive(signature),
-            "Block3" => primitives::block3::get_primitive(signature),
-            _ => None,
-        };
-        // println!(
-        //     "loading primitive of '{}>>#{}': {}",
-        //     class_name,
-        //     signature,
-        //     primitive.is_some()
-        // );
-        primitive.map(MethodKind::Primitive).unwrap_or_else(|| {
-            MethodKind::NotImplemented(format!("{}>>#{}", class_name, signature))
-        })
-        // .unwrap_or_else(|| panic!("unimplemented primitive: '{}>>#{}'", class_name, signature))
-    }
-
     /// Whether this invocable is a primitive.
     pub fn is_primitive(&self) -> bool {
         matches!(self, Self::Primitive(_))

--- a/som-interpreter-ast/src/primitives/array.rs
+++ b/som-interpreter-ast/src/primitives/array.rs
@@ -8,6 +8,14 @@ use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::value::Value;
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("at:", self::at, true),
+    ("at:put:", self::at_put, true),
+    ("length", self::length, true),
+];
+
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[("new:", self::new, true)];
+
 fn at(_: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "Array>>#at:";
 
@@ -74,13 +82,18 @@ fn new(_: &mut Universe, args: Vec<Value>) -> Return {
     }
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "at:" => Some(self::at),
-        "at:put:" => Some(self::at_put),
-        "length" => Some(self::length),
-        "new:" => Some(self::new),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-ast/src/primitives/blocks.rs
+++ b/som-interpreter-ast/src/primitives/blocks.rs
@@ -10,6 +10,12 @@ use crate::value::Value;
 pub mod block1 {
     use super::*;
 
+    pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+        ("value", self::value, true),
+        ("restart", self::restart, false),
+    ];
+    pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
     fn value(universe: &mut Universe, args: Vec<Value>) -> Return {
         const SIGNATURE: &str = "Block1>>#value";
 
@@ -34,19 +40,29 @@ pub mod block1 {
         Return::Restart
     }
 
-    /// Search for a primitive matching the given signature.
-    pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-        match signature.as_ref() {
-            "value" => Some(self::value),
-            "restart" => Some(self::restart),
-            _ => None,
-        }
+    /// Search for an instance primitive matching the given signature.
+    pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+        INSTANCE_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
+    }
+
+    /// Search for a class primitive matching the given signature.
+    pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+        CLASS_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
     }
 }
 
 /// Primitives for the **Block2** class.
 pub mod block2 {
     use super::*;
+
+    pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[("value:", self::value, true)];
+    pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
     fn value(universe: &mut Universe, args: Vec<Value>) -> Return {
         const SIGNATURE: &str = "Block2>>#value:";
@@ -65,18 +81,30 @@ pub mod block2 {
         )
     }
 
-    /// Search for a primitive matching the given signature.
-    pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-        match signature.as_ref() {
-            "value:" => Some(self::value),
-            _ => None,
-        }
+    /// Search for an instance primitive matching the given signature.
+    pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+        INSTANCE_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
+    }
+
+    /// Search for a class primitive matching the given signature.
+    pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+        CLASS_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
     }
 }
 
 /// Primitives for the **Block3** class.
 pub mod block3 {
     use super::*;
+
+    pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] =
+        &[("value:with:", self::value_with, true)];
+    pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
     fn value_with(universe: &mut Universe, args: Vec<Value>) -> Return {
         const SIGNATURE: &str = "Block3>>#value:with:";
@@ -96,11 +124,19 @@ pub mod block3 {
         )
     }
 
-    /// Search for a primitive matching the given signature.
-    pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-        match signature.as_ref() {
-            "value:with:" => Some(self::value_with),
-            _ => None,
-        }
+    /// Search for an instance primitive matching the given signature.
+    pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+        INSTANCE_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
+    }
+
+    /// Search for a class primitive matching the given signature.
+    pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+        CLASS_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
     }
 }

--- a/som-interpreter-ast/src/primitives/class.rs
+++ b/som-interpreter-ast/src/primitives/class.rs
@@ -10,6 +10,15 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::SOMRef;
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("new", self::new, true),
+    ("name", self::name, true),
+    ("fields", self::fields, true),
+    ("methods", self::methods, true),
+    ("superclass", self::superclass, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
 fn superclass(_: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "Class>>#superclass";
 
@@ -88,14 +97,18 @@ fn fields(universe: &mut Universe, args: Vec<Value>) -> Return {
     Return::Local(Value::Array(Rc::new(RefCell::new(fields))))
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "new" => Some(self::new),
-        "name" => Some(self::name),
-        "fields" => Some(self::fields),
-        "methods" => Some(self::methods),
-        "superclass" => Some(self::superclass),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-ast/src/primitives/double.rs
+++ b/som-interpreter-ast/src/primitives/double.rs
@@ -8,6 +8,26 @@ use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::value::Value;
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("+", self::plus, true),
+    ("-", self::minus, true),
+    ("*", self::times, true),
+    ("//", self::divide, true),
+    ("%", self::modulo, true),
+    ("=", self::eq, true),
+    ("<", self::lt, true),
+    ("sqrt", self::sqrt, true),
+    ("round", self::round, true),
+    ("cos", self::cos, true),
+    ("sin", self::sin, true),
+    ("asString", self::as_string, true),
+    ("asInteger", self::as_integer, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("fromString:", self::from_string, true),
+    ("PositiveInfinity", self::positive_infinity, true),
+];
+
 macro_rules! promote {
     ($signature:expr, $value:expr) => {
         match $value {
@@ -219,24 +239,18 @@ fn positive_infinity(_: &mut Universe, _: Vec<Value>) -> Return {
     Return::Local(Value::Double(f64::INFINITY))
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "+" => Some(self::plus),
-        "-" => Some(self::minus),
-        "*" => Some(self::times),
-        "//" => Some(self::divide),
-        "%" => Some(self::modulo),
-        "=" => Some(self::eq),
-        "<" => Some(self::lt),
-        "sqrt" => Some(self::sqrt),
-        "round" => Some(self::round),
-        "cos" => Some(self::cos),
-        "sin" => Some(self::sin),
-        "fromString:" => Some(self::from_string),
-        "asString" => Some(self::as_string),
-        "asInteger" => Some(self::as_integer),
-        "PositiveInfinity" => Some(self::positive_infinity),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-ast/src/primitives/integer.rs
+++ b/som-interpreter-ast/src/primitives/integer.rs
@@ -11,6 +11,29 @@ use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::value::Value;
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("<", self::lt, true),
+    ("=", self::eq, true),
+    ("+", self::plus, true),
+    ("-", self::minus, true),
+    ("*", self::times, true),
+    ("/", self::divide, true),
+    ("//", self::divide_float, true),
+    ("%", self::modulo, true),
+    ("rem:", self::remainder, true),
+    ("&", self::bitand, true),
+    ("<<", self::shift_left, true),
+    (">>>", self::shift_right, true),
+    ("bitXor:", self::bitxor, true),
+    ("sqrt", self::sqrt, true),
+    ("asString", self::as_string, true),
+    ("atRandom", self::at_random, true),
+    ("as32BitSignedValue", self::as_32bit_signed_value, true),
+    ("as32BitUnsignedValue", self::as_32bit_unsigned_value, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] =
+    &[("fromString:", self::from_string, true)];
+
 macro_rules! demote {
     ($expr:expr) => {{
         let value = $expr;
@@ -438,28 +461,18 @@ fn shift_right(_: &mut Universe, args: Vec<Value>) -> Return {
     }
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "fromString:" => Some(self::from_string),
-        "asString" => Some(self::as_string),
-        "atRandom" => Some(self::at_random),
-        "as32BitSignedValue" => Some(self::as_32bit_signed_value),
-        "as32BitUnsignedValue" => Some(self::as_32bit_unsigned_value),
-        "<" => Some(self::lt),
-        "=" => Some(self::eq),
-        "+" => Some(self::plus),
-        "-" => Some(self::minus),
-        "*" => Some(self::times),
-        "/" => Some(self::divide),
-        "//" => Some(self::divide_float),
-        "%" => Some(self::modulo),
-        "rem:" => Some(self::remainder),
-        "&" => Some(self::bitand),
-        "<<" => Some(self::shift_left),
-        ">>>" => Some(self::shift_right),
-        "bitXor:" => Some(self::bitxor),
-        "sqrt" => Some(self::sqrt),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-ast/src/primitives/method.rs
+++ b/som-interpreter-ast/src/primitives/method.rs
@@ -4,6 +4,13 @@ use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::value::Value;
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("holder", self::holder, true),
+    ("signature", self::signature, true),
+    ("invokeOn:with:", self::invoke_on_with, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
 fn holder(_: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "Method>>#holder";
 
@@ -46,12 +53,18 @@ fn invoke_on_with(universe: &mut Universe, args: Vec<Value>) -> Return {
     invokable.invoke(universe, args)
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "holder" => Some(self::holder),
-        "signature" => Some(self::signature),
-        "invokeOn:with:" => Some(self::invoke_on_with),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-ast/src/primitives/mod.rs
+++ b/som-interpreter-ast/src/primitives/mod.rs
@@ -46,3 +46,45 @@ macro_rules! expect_args {
         };
     };
 }
+
+pub fn get_class_primitives(
+    class_name: &str,
+) -> Option<&'static [(&'static str, PrimitiveFn, bool)]> {
+    match class_name {
+        "Array" => Some(self::array::CLASS_PRIMITIVES),
+        "Block1" => Some(self::block1::CLASS_PRIMITIVES),
+        "Block2" => Some(self::block2::CLASS_PRIMITIVES),
+        "Block3" => Some(self::block3::CLASS_PRIMITIVES),
+        "Class" => Some(self::class::CLASS_PRIMITIVES),
+        "Double" => Some(self::double::CLASS_PRIMITIVES),
+        "Integer" => Some(self::integer::CLASS_PRIMITIVES),
+        "Method" => Some(self::method::CLASS_PRIMITIVES),
+        "Primitive" => Some(self::method::CLASS_PRIMITIVES),
+        "Object" => Some(self::object::CLASS_PRIMITIVES),
+        "String" => Some(self::string::CLASS_PRIMITIVES),
+        "Symbol" => Some(self::symbol::CLASS_PRIMITIVES),
+        "System" => Some(self::system::CLASS_PRIMITIVES),
+        _ => None,
+    }
+}
+
+pub fn get_instance_primitives(
+    class_name: &str,
+) -> Option<&'static [(&'static str, PrimitiveFn, bool)]> {
+    match class_name {
+        "Array" => Some(self::array::INSTANCE_PRIMITIVES),
+        "Block1" => Some(self::block1::INSTANCE_PRIMITIVES),
+        "Block2" => Some(self::block2::INSTANCE_PRIMITIVES),
+        "Block3" => Some(self::block3::INSTANCE_PRIMITIVES),
+        "Class" => Some(self::class::INSTANCE_PRIMITIVES),
+        "Double" => Some(self::double::INSTANCE_PRIMITIVES),
+        "Integer" => Some(self::integer::INSTANCE_PRIMITIVES),
+        "Method" => Some(self::method::INSTANCE_PRIMITIVES),
+        "Primitive" => Some(self::method::INSTANCE_PRIMITIVES),
+        "Object" => Some(self::object::INSTANCE_PRIMITIVES),
+        "String" => Some(self::string::INSTANCE_PRIMITIVES),
+        "Symbol" => Some(self::symbol::INSTANCE_PRIMITIVES),
+        "System" => Some(self::system::INSTANCE_PRIMITIVES),
+        _ => None,
+    }
+}

--- a/som-interpreter-ast/src/primitives/object.rs
+++ b/som-interpreter-ast/src/primitives/object.rs
@@ -9,6 +9,24 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::{expect_args, SOMRef};
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("class", self::class, true),
+    ("objectSize", self::object_size, true),
+    ("hashcode", self::hashcode, true),
+    ("perform:", self::perform, true),
+    ("perform:withArguments:", self::perform_with_arguments, true),
+    ("perform:inSuperclass:", self::perform_in_super_class, true),
+    (
+        "perform:withArguments:inSuperclass:",
+        self::perform_with_arguments_in_super_class,
+        true,
+    ),
+    ("instVarAt:", self::inst_var_at, true),
+    ("instVarAt:put:", self::inst_var_at_put, true),
+    ("==", self::eq, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
 fn class(universe: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &'static str = "Object>>#class";
 
@@ -245,19 +263,18 @@ fn gather_locals(universe: &mut Universe, class: SOMRef<Class>) -> Vec<String> {
     fields
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "class" => Some(self::class),
-        "objectSize" => Some(self::object_size),
-        "hashcode" => Some(self::hashcode),
-        "perform:" => Some(self::perform),
-        "perform:withArguments:" => Some(self::perform_with_arguments),
-        "perform:inSuperclass:" => Some(self::perform_in_super_class),
-        "perform:withArguments:inSuperclass:" => Some(self::perform_with_arguments_in_super_class),
-        "instVarAt:" => Some(self::inst_var_at),
-        "instVarAt:put:" => Some(self::inst_var_at_put),
-        "==" => Some(self::eq),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-ast/src/primitives/string.rs
+++ b/som-interpreter-ast/src/primitives/string.rs
@@ -9,6 +9,19 @@ use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::value::Value;
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("length", self::length, true),
+    ("hashcode", self::hashcode, true),
+    ("isLetters", self::is_letters, true),
+    ("isDigits", self::is_digits, true),
+    ("isWhiteSpace", self::is_whitespace, true),
+    ("asSymbol", self::as_symbol, true),
+    ("concatenate:", self::concatenate, true),
+    ("primSubstringFrom:to:", self::prim_substring_from_to, true),
+    ("=", self::eq, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
 fn length(universe: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "String>>#length";
 
@@ -176,18 +189,18 @@ fn prim_substring_from_to(universe: &mut Universe, args: Vec<Value>) -> Return {
     Return::Local(Value::String(string))
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "length" => Some(self::length),
-        "hashcode" => Some(self::hashcode),
-        "isLetters" => Some(self::is_letters),
-        "isDigits" => Some(self::is_digits),
-        "isWhiteSpace" => Some(self::is_whitespace),
-        "asSymbol" => Some(self::as_symbol),
-        "concatenate:" => Some(self::concatenate),
-        "primSubstringFrom:to:" => Some(self::prim_substring_from_to),
-        "=" => Some(self::eq),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-ast/src/primitives/symbol.rs
+++ b/som-interpreter-ast/src/primitives/symbol.rs
@@ -6,6 +6,10 @@ use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::value::Value;
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] =
+    &[("asString", self::as_string, true)];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
 fn as_string(universe: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "Symbol>>#asString";
 
@@ -18,10 +22,18 @@ fn as_string(universe: &mut Universe, args: Vec<Value>) -> Return {
     )))
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "asString" => Some(self::as_string),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-ast/src/primitives/system.rs
+++ b/som-interpreter-ast/src/primitives/system.rs
@@ -1,6 +1,4 @@
 use std::convert::TryFrom;
-// use std::io::BufRead;
-// use std::rc::Rc;
 
 use crate::expect_args;
 use crate::invokable::Return;
@@ -8,17 +6,18 @@ use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::value::Value;
 
-// fn read_line(_: &mut Universe, args: Vec<Value>) -> Return {
-//     const SIGNATURE: &str = "System>>#readLine";
-
-//     expect_args!(SIGNATURE, args, [Value::System]);
-
-//     match std::io::stdin().lock().lines().next() {
-//         Some(Ok(line)) => Return::Local(Value::String(Rc::new(line))),
-//         Some(Err(err)) => Return::Exception(format!("'{}': {}", SIGNATURE, err)),
-//         None => Return::Exception(format!("'{}': {}", SIGNATURE, "error")),
-//     }
-// }
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("printString:", self::print_string, true),
+    ("printNewline", self::print_newline, true),
+    ("load:", self::load, true),
+    ("ticks", self::ticks, true),
+    ("time", self::time, true),
+    ("fullGC", self::full_gc, true),
+    ("exit:", self::exit, true),
+    ("global:", self::global, true),
+    ("global:put:", self::global_put, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
 fn print_string(universe: &mut Universe, args: Vec<Value>) -> Return {
     const SIGNATURE: &str = "System>>#printString:";
@@ -133,19 +132,18 @@ fn full_gc(_: &mut Universe, args: Vec<Value>) -> Return {
     Return::Local(Value::Boolean(false))
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        // "readLine" => Some(self::read_line),
-        "printString:" => Some(self::print_string),
-        "printNewline" => Some(self::print_newline),
-        "load:" => Some(self::load),
-        "ticks" => Some(self::ticks),
-        "time" => Some(self::time),
-        "fullGC" => Some(self::full_gc),
-        "exit:" => Some(self::exit),
-        "global:" => Some(self::global),
-        "global:put:" => Some(self::global_put),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-bc/src/interpreter.rs
+++ b/som-interpreter-bc/src/interpreter.rs
@@ -230,6 +230,12 @@ impl Interpreter {
                                 func(self, universe);
                             }
                             MethodKind::NotImplemented(err) => {
+                                let self_value = self.stack.iter().nth_back(nb_params).unwrap();
+                                println!(
+                                    "{}>>#{}",
+                                    self_value.class(&universe).borrow().name(),
+                                    method.signature()
+                                );
                                 panic!("Primitive `#{}` not implemented", err)
                             }
                         }

--- a/som-interpreter-bc/src/method.rs
+++ b/som-interpreter-bc/src/method.rs
@@ -7,7 +7,6 @@ use crate::class::Class;
 use crate::compiler::Literal;
 use crate::frame::FrameKind;
 use crate::interpreter::Interpreter;
-use crate::primitives;
 use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::value::Value;
@@ -32,42 +31,6 @@ pub enum MethodKind {
 }
 
 impl MethodKind {
-    /// Return the interpreter primitive matching a given class name and signature.
-    pub fn primitive_from_signature(
-        class_name: impl AsRef<str>,
-        signature: impl AsRef<str>,
-    ) -> Self {
-        let class_name = class_name.as_ref();
-        let signature = signature.as_ref();
-        let primitive = match class_name {
-            "Object" => primitives::object::get_primitive(signature),
-            "Class" => primitives::class::get_primitive(signature),
-            "Integer" => primitives::integer::get_primitive(signature),
-            "Double" => primitives::double::get_primitive(signature),
-            "Array" => primitives::array::get_primitive(signature),
-            "String" => primitives::string::get_primitive(signature),
-            "Symbol" => primitives::symbol::get_primitive(signature),
-            "System" => primitives::system::get_primitive(signature),
-            "Method" => primitives::method::get_primitive(signature),
-            "Primitive" => primitives::method::get_primitive(signature),
-            "Block" => primitives::block1::get_primitive(signature),
-            "Block1" => primitives::block1::get_primitive(signature),
-            "Block2" => primitives::block2::get_primitive(signature),
-            "Block3" => primitives::block3::get_primitive(signature),
-            _ => None,
-        };
-        // println!(
-        //     "loading primitive of '{}>>#{}': {}",
-        //     class_name,
-        //     signature,
-        //     primitive.is_some()
-        // );
-        primitive.map(MethodKind::Primitive).unwrap_or_else(|| {
-            MethodKind::NotImplemented(format!("{}>>#{}", class_name, signature))
-        })
-        // .unwrap_or_else(|| panic!("unimplemented primitive: '{}>>#{}'", class_name, signature))
-    }
-
     /// Whether this invocable is a primitive.
     pub fn is_primitive(&self) -> bool {
         matches!(self, Self::Primitive(_))

--- a/som-interpreter-bc/src/primitives/array.rs
+++ b/som-interpreter-bc/src/primitives/array.rs
@@ -8,6 +8,14 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::{expect_args, reverse};
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("at:", self::at, true),
+    ("at:put:", self::at_put, true),
+    ("length", self::length, true),
+];
+
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[("new:", self::new, true)];
+
 fn at(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Array>>#at:";
 
@@ -76,13 +84,18 @@ fn new(interpreter: &mut Interpreter, _: &mut Universe) {
     }
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "at:" => Some(self::at),
-        "at:put:" => Some(self::at_put),
-        "length" => Some(self::length),
-        "new:" => Some(self::new),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-bc/src/primitives/blocks.rs
+++ b/som-interpreter-bc/src/primitives/blocks.rs
@@ -9,6 +9,12 @@ use crate::{expect_args, reverse};
 pub mod block1 {
     use super::*;
 
+    pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+        ("value", self::value, true),
+        ("restart", self::restart, false),
+    ];
+    pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
     fn value(interpreter: &mut Interpreter, _: &mut Universe) {
         const SIGNATURE: &str = "Block1>>#value";
 
@@ -32,19 +38,29 @@ pub mod block1 {
         frame.borrow_mut().bytecode_idx = 0;
     }
 
-    /// Search for a primitive matching the given signature.
-    pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-        match signature.as_ref() {
-            "value" => Some(self::value),
-            "restart" => Some(self::restart),
-            _ => None,
-        }
+    /// Search for an instance primitive matching the given signature.
+    pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+        INSTANCE_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
+    }
+
+    /// Search for a class primitive matching the given signature.
+    pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+        CLASS_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
     }
 }
 
 /// Primitives for the **Block2** class.
 pub mod block2 {
     use super::*;
+
+    pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[("value:", self::value, true)];
+    pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
     fn value(interpreter: &mut Interpreter, _: &mut Universe) {
         const SIGNATURE: &str = "Block2>>#value:";
@@ -62,18 +78,30 @@ pub mod block2 {
         frame.borrow_mut().args.push(argument);
     }
 
-    /// Search for a primitive matching the given signature.
-    pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-        match signature.as_ref() {
-            "value:" => Some(self::value),
-            _ => None,
-        }
+    /// Search for an instance primitive matching the given signature.
+    pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+        INSTANCE_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
+    }
+
+    /// Search for a class primitive matching the given signature.
+    pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+        CLASS_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
     }
 }
 
 /// Primitives for the **Block3** class.
 pub mod block3 {
     use super::*;
+
+    pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] =
+        &[("value:with:", self::value_with, true)];
+    pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
     fn value_with(interpreter: &mut Interpreter, _: &mut Universe) {
         const SIGNATURE: &str = "Block3>>#value:with:";
@@ -93,11 +121,19 @@ pub mod block3 {
         frame.borrow_mut().args.push(argument2);
     }
 
-    /// Search for a primitive matching the given signature.
-    pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-        match signature.as_ref() {
-            "value:with:" => Some(self::value_with),
-            _ => None,
-        }
+    /// Search for an instance primitive matching the given signature.
+    pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+        INSTANCE_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
+    }
+
+    /// Search for a class primitive matching the given signature.
+    pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+        CLASS_PRIMITIVES
+            .iter()
+            .find(|it| it.0 == signature)
+            .map(|it| it.1)
     }
 }

--- a/som-interpreter-bc/src/primitives/class.rs
+++ b/som-interpreter-bc/src/primitives/class.rs
@@ -8,6 +8,15 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::{expect_args, reverse};
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("new", self::new, true),
+    ("name", self::name, true),
+    ("fields", self::fields, true),
+    ("methods", self::methods, true),
+    ("superclass", self::superclass, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
 fn superclass(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Class>>#superclass";
 
@@ -81,14 +90,18 @@ fn fields(interpreter: &mut Interpreter, _: &mut Universe) {
     ))));
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "new" => Some(self::new),
-        "name" => Some(self::name),
-        "fields" => Some(self::fields),
-        "methods" => Some(self::methods),
-        "superclass" => Some(self::superclass),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-bc/src/primitives/double.rs
+++ b/som-interpreter-bc/src/primitives/double.rs
@@ -8,6 +8,26 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::{expect_args, reverse};
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("+", self::plus, true),
+    ("-", self::minus, true),
+    ("*", self::times, true),
+    ("//", self::divide, true),
+    ("%", self::modulo, true),
+    ("=", self::eq, true),
+    ("<", self::lt, true),
+    ("sqrt", self::sqrt, true),
+    ("round", self::round, true),
+    ("cos", self::cos, true),
+    ("sin", self::sin, true),
+    ("asString", self::as_string, true),
+    ("asInteger", self::as_integer, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("fromString:", self::from_string, true),
+    ("PositiveInfinity", self::positive_infinity, true),
+];
+
 macro_rules! promote {
     ($signature:expr, $value:expr) => {
         match $value {
@@ -221,24 +241,18 @@ fn positive_infinity(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Double(f64::INFINITY));
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "+" => Some(self::plus),
-        "-" => Some(self::minus),
-        "*" => Some(self::times),
-        "//" => Some(self::divide),
-        "%" => Some(self::modulo),
-        "=" => Some(self::eq),
-        "<" => Some(self::lt),
-        "sqrt" => Some(self::sqrt),
-        "round" => Some(self::round),
-        "cos" => Some(self::cos),
-        "sin" => Some(self::sin),
-        "fromString:" => Some(self::from_string),
-        "asString" => Some(self::as_string),
-        "asInteger" => Some(self::as_integer),
-        "PositiveInfinity" => Some(self::positive_infinity),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-bc/src/primitives/integer.rs
+++ b/som-interpreter-bc/src/primitives/integer.rs
@@ -11,6 +11,29 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::{expect_args, reverse};
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("<", self::lt, true),
+    ("=", self::eq, true),
+    ("+", self::plus, true),
+    ("-", self::minus, true),
+    ("*", self::times, true),
+    ("/", self::divide, true),
+    ("//", self::divide_float, true),
+    ("%", self::modulo, true),
+    ("rem:", self::remainder, true),
+    ("&", self::bitand, true),
+    ("<<", self::shift_left, true),
+    (">>>", self::shift_right, true),
+    ("bitXor:", self::bitxor, true),
+    ("sqrt", self::sqrt, true),
+    ("asString", self::as_string, true),
+    ("atRandom", self::at_random, true),
+    ("as32BitSignedValue", self::as_32bit_signed_value, true),
+    ("as32BitUnsignedValue", self::as_32bit_unsigned_value, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] =
+    &[("fromString:", self::from_string, true)];
+
 macro_rules! demote {
     ($interpreter:expr, $expr:expr) => {{
         let value = $expr;
@@ -512,28 +535,18 @@ fn shift_right(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "fromString:" => Some(self::from_string),
-        "asString" => Some(self::as_string),
-        "atRandom" => Some(self::at_random),
-        "as32BitSignedValue" => Some(self::as_32bit_signed_value),
-        "as32BitUnsignedValue" => Some(self::as_32bit_unsigned_value),
-        "<" => Some(self::lt),
-        "=" => Some(self::eq),
-        "+" => Some(self::plus),
-        "-" => Some(self::minus),
-        "*" => Some(self::times),
-        "/" => Some(self::divide),
-        "//" => Some(self::divide_float),
-        "%" => Some(self::modulo),
-        "rem:" => Some(self::remainder),
-        "&" => Some(self::bitand),
-        "<<" => Some(self::shift_left),
-        ">>>" => Some(self::shift_right),
-        "bitXor:" => Some(self::bitxor),
-        "sqrt" => Some(self::sqrt),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-bc/src/primitives/method.rs
+++ b/som-interpreter-bc/src/primitives/method.rs
@@ -4,6 +4,13 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::{expect_args, reverse};
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("holder", self::holder, true),
+    ("signature", self::signature, true),
+    ("invokeOn:with:", self::invoke_on_with, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
 fn holder(interpreter: &mut Interpreter, _: &mut Universe) {
     const SIGNATURE: &str = "Method>>#holder";
 
@@ -41,12 +48,18 @@ fn invoke_on_with(interpreter: &mut Interpreter, universe: &mut Universe) {
     invokable.invoke(interpreter, universe, receiver, args);
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "holder" => Some(self::holder),
-        "signature" => Some(self::signature),
-        "invokeOn:with:" => Some(self::invoke_on_with),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-bc/src/primitives/mod.rs
+++ b/som-interpreter-bc/src/primitives/mod.rs
@@ -56,3 +56,45 @@ macro_rules! expect_args {
         reverse!($signature, $frame, [ $( $ptrn $( => $name )? ,)* ], [])
     };
 }
+
+pub fn get_class_primitives(
+    class_name: &str,
+) -> Option<&'static [(&'static str, PrimitiveFn, bool)]> {
+    match class_name {
+        "Array" => Some(self::array::CLASS_PRIMITIVES),
+        "Block1" => Some(self::block1::CLASS_PRIMITIVES),
+        "Block2" => Some(self::block2::CLASS_PRIMITIVES),
+        "Block3" => Some(self::block3::CLASS_PRIMITIVES),
+        "Class" => Some(self::class::CLASS_PRIMITIVES),
+        "Double" => Some(self::double::CLASS_PRIMITIVES),
+        "Integer" => Some(self::integer::CLASS_PRIMITIVES),
+        "Method" => Some(self::method::CLASS_PRIMITIVES),
+        "Primitive" => Some(self::method::CLASS_PRIMITIVES),
+        "Object" => Some(self::object::CLASS_PRIMITIVES),
+        "String" => Some(self::string::CLASS_PRIMITIVES),
+        "Symbol" => Some(self::symbol::CLASS_PRIMITIVES),
+        "System" => Some(self::system::CLASS_PRIMITIVES),
+        _ => None,
+    }
+}
+
+pub fn get_instance_primitives(
+    class_name: &str,
+) -> Option<&'static [(&'static str, PrimitiveFn, bool)]> {
+    match class_name {
+        "Array" => Some(self::array::INSTANCE_PRIMITIVES),
+        "Block1" => Some(self::block1::INSTANCE_PRIMITIVES),
+        "Block2" => Some(self::block2::INSTANCE_PRIMITIVES),
+        "Block3" => Some(self::block3::INSTANCE_PRIMITIVES),
+        "Class" => Some(self::class::INSTANCE_PRIMITIVES),
+        "Double" => Some(self::double::INSTANCE_PRIMITIVES),
+        "Integer" => Some(self::integer::INSTANCE_PRIMITIVES),
+        "Method" => Some(self::method::INSTANCE_PRIMITIVES),
+        "Primitive" => Some(self::method::INSTANCE_PRIMITIVES),
+        "Object" => Some(self::object::INSTANCE_PRIMITIVES),
+        "String" => Some(self::string::INSTANCE_PRIMITIVES),
+        "Symbol" => Some(self::symbol::INSTANCE_PRIMITIVES),
+        "System" => Some(self::system::INSTANCE_PRIMITIVES),
+        _ => None,
+    }
+}

--- a/som-interpreter-bc/src/primitives/object.rs
+++ b/som-interpreter-bc/src/primitives/object.rs
@@ -8,6 +8,24 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::{expect_args, reverse};
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("class", self::class, true),
+    ("objectSize", self::object_size, true),
+    ("hashcode", self::hashcode, true),
+    ("perform:", self::perform, true),
+    ("perform:withArguments:", self::perform_with_arguments, true),
+    ("perform:inSuperclass:", self::perform_in_super_class, true),
+    (
+        "perform:withArguments:inSuperclass:",
+        self::perform_with_arguments_in_super_class,
+        true,
+    ),
+    ("instVarAt:", self::inst_var_at, true),
+    ("instVarAt:put:", self::inst_var_at_put, true),
+    ("==", self::eq, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
 fn class(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &'static str = "Object>>#class";
 
@@ -230,19 +248,18 @@ fn inst_var_at_put(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(local);
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "class" => Some(self::class),
-        "objectSize" => Some(self::object_size),
-        "hashcode" => Some(self::hashcode),
-        "perform:" => Some(self::perform),
-        "perform:withArguments:" => Some(self::perform_with_arguments),
-        "perform:inSuperclass:" => Some(self::perform_in_super_class),
-        "perform:withArguments:inSuperclass:" => Some(self::perform_with_arguments_in_super_class),
-        "instVarAt:" => Some(self::inst_var_at),
-        "instVarAt:put:" => Some(self::inst_var_at_put),
-        "==" => Some(self::eq),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-bc/src/primitives/string.rs
+++ b/som-interpreter-bc/src/primitives/string.rs
@@ -9,6 +9,19 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::{expect_args, reverse};
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("length", self::length, true),
+    ("hashcode", self::hashcode, true),
+    ("isLetters", self::is_letters, true),
+    ("isDigits", self::is_digits, true),
+    ("isWhiteSpace", self::is_whitespace, true),
+    ("asSymbol", self::as_symbol, true),
+    ("concatenate:", self::concatenate, true),
+    ("primSubstringFrom:to:", self::prim_substring_from_to, true),
+    ("=", self::eq, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
 fn length(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &str = "String>>#length";
 
@@ -180,18 +193,18 @@ fn prim_substring_from_to(interpreter: &mut Interpreter, universe: &mut Universe
     interpreter.stack.push(Value::String(string))
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "length" => Some(self::length),
-        "hashcode" => Some(self::hashcode),
-        "isLetters" => Some(self::is_letters),
-        "isDigits" => Some(self::is_digits),
-        "isWhiteSpace" => Some(self::is_whitespace),
-        "asSymbol" => Some(self::as_symbol),
-        "concatenate:" => Some(self::concatenate),
-        "primSubstringFrom:to:" => Some(self::prim_substring_from_to),
-        "=" => Some(self::eq),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-bc/src/primitives/symbol.rs
+++ b/som-interpreter-bc/src/primitives/symbol.rs
@@ -6,6 +6,10 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::{expect_args, reverse};
 
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] =
+    &[("asString", self::as_string, true)];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
+
 fn as_string(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &str = "Symbol>>#asString";
 
@@ -18,10 +22,18 @@ fn as_string(interpreter: &mut Interpreter, universe: &mut Universe) {
     )));
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        "asString" => Some(self::as_string),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }

--- a/som-interpreter-bc/src/primitives/system.rs
+++ b/som-interpreter-bc/src/primitives/system.rs
@@ -1,6 +1,4 @@
 use std::convert::TryFrom;
-// use std::io::BufRead;
-// use std::rc::Rc;
 
 use crate::interpreter::Interpreter;
 use crate::primitives::PrimitiveFn;
@@ -8,17 +6,18 @@ use crate::universe::Universe;
 use crate::value::Value;
 use crate::{expect_args, reverse};
 
-// fn read_line(interpreter: &mut Interpreter, _: &mut Universe) {
-//     const SIGNATURE: &str = "System>>#readLine";
-//
-//     expect_args!(SIGNATURE, interpreter, [Value::System]);
-//
-//     match std::io::stdin().lock().lines().next() {
-//         Some(Ok(line)) => interpreter.stack.push(Value::String(Rc::new(line))),
-//         Some(Err(err)) => panic!("'{}': {}", SIGNATURE, err),
-//         None => panic!("'{}': {}", SIGNATURE, "error"),
-//     }
-// }
+pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
+    ("printString:", self::print_string, true),
+    ("printNewline", self::print_newline, true),
+    ("load:", self::load, true),
+    ("ticks", self::ticks, true),
+    ("time", self::time, true),
+    ("fullGC", self::full_gc, true),
+    ("exit:", self::exit, true),
+    ("global:", self::global, true),
+    ("global:put:", self::global_put, true),
+];
+pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
 fn print_string(interpreter: &mut Interpreter, universe: &mut Universe) {
     const SIGNATURE: &str = "System>>#printString:";
@@ -35,6 +34,8 @@ fn print_string(interpreter: &mut Interpreter, universe: &mut Universe) {
     };
 
     print!("{}", string);
+    use std::io::Write;
+    std::io::stdout().flush().unwrap();
     interpreter.stack.push(Value::System)
 }
 
@@ -133,19 +134,18 @@ fn full_gc(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Boolean(false))
 }
 
-/// Search for a primitive matching the given signature.
-pub fn get_primitive(signature: impl AsRef<str>) -> Option<PrimitiveFn> {
-    match signature.as_ref() {
-        // "readLine" => Some(self::read_line),
-        "printString:" => Some(self::print_string),
-        "printNewline" => Some(self::print_newline),
-        "load:" => Some(self::load),
-        "ticks" => Some(self::ticks),
-        "time" => Some(self::time),
-        "fullGC" => Some(self::full_gc),
-        "exit:" => Some(self::exit),
-        "global:" => Some(self::global),
-        "global:put:" => Some(self::global_put),
-        _ => None,
-    }
+/// Search for an instance primitive matching the given signature.
+pub fn get_instance_primitive(signature: &str) -> Option<PrimitiveFn> {
+    INSTANCE_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
+}
+
+/// Search for a class primitive matching the given signature.
+pub fn get_class_primitive(signature: &str) -> Option<PrimitiveFn> {
+    CLASS_PRIMITIVES
+        .iter()
+        .find(|it| it.0 == signature)
+        .map(|it| it.1)
 }


### PR DESCRIPTION
This PR refactors how primitives are installed within classes in both interpreters to allow installing primitives for both undeclared methods and user-defined methods instead of just those marked with `primitive`.  

This change should then allow to implement the `Symbol>>#=` primitive (which is not declared in the core lib), and should allow the symbol equality tests to finally pass.
