### PR TITLE
Bytecode disassembly of class methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ But, since the '-c' accepts multiple files, you might need to add the '--' argum
 ./target/release/som-interpreter-bc -c core-lib/Smalltalk -- core-lib/Examples/Hello.som
 ```
 
+When using the bytecode interpreter, you have the option to dissasemble a given class' methods using `-d` (or `--disassemble`), like so:
+
+```bash
+./target/release/som-interpreter-bc -c core-lib/Smalltalk -d core-lib/Examples/Hello.som
+# OR:
+./target/release/som-interpreter-bc -c core-lib/Smalltalk core-lib/Examples -d Hello
+# OR (for disassembling only specific methods):
+./target/release/som-interpreter-bc -c core-lib/Smalltalk core-lib/Examples -d Hello first:method: second:method:
+```
+
 For other purposes, you can use '-h' (or '--help') to print the complete help message:
 
 ```bash

--- a/som-interpreter-bc/README.md
+++ b/som-interpreter-bc/README.md
@@ -3,6 +3,6 @@ The SOM Interpreter
 
 This is the interpreter for the Simple Object Machine.
 
-It is AST-based, in that it works by recursively traversing and evaluating nodes from the Abstract Syntax Tree from **`som-core`**.  
+It is bytecode-based, in that it works by compiling nodes from the Abstract Syntax Tree from **`som-core`** into stack-based bytecode instructions and then executing them.  
 
 Resources are managed and tracked through reference-counting (using Rust's **`Rc`**/**`Weak`** types).  

--- a/som-interpreter-bc/src/block.rs
+++ b/som-interpreter-bc/src/block.rs
@@ -7,14 +7,14 @@ use som_core::bytecode::Bytecode;
 use crate::class::Class;
 use crate::compiler::Literal;
 use crate::frame::Frame;
+use crate::interner::Interned;
 use crate::method::Method;
 use crate::universe::Universe;
-use crate::value::Value;
 use crate::SOMRef;
 
 #[derive(Clone)]
 pub struct BlockInfo {
-    pub locals: Vec<Value>,
+    pub locals: Vec<Interned>,
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
     pub nb_params: usize,

--- a/som-interpreter-bc/src/disassembler.rs
+++ b/som-interpreter-bc/src/disassembler.rs
@@ -1,0 +1,159 @@
+use som_core::bytecode::Bytecode;
+
+use crate::block::Block;
+use crate::class::Class;
+use crate::compiler::Literal;
+use crate::interner::Interned;
+use crate::method::MethodEnv;
+use crate::universe::Universe;
+
+pub fn disassemble_method_body(universe: &Universe, class: &Class, env: &MethodEnv) {
+    disassemble_body(universe, class, 1, &mut vec![env])
+}
+
+fn disassemble_body(
+    universe: &Universe,
+    class: &Class,
+    level: usize,
+    env: &mut Vec<&dyn FrameEnv>,
+) {
+    let padding = "  |".repeat(level);
+    let current = env.last().copied().unwrap();
+    for bytecode in current.get_body().into_iter().copied() {
+        print!("{padding} {0}", bytecode.padded_name());
+
+        match bytecode {
+            Bytecode::Halt => {
+                println!();
+            }
+            Bytecode::Dup => {
+                println!();
+            }
+            Bytecode::PushLocal(up_idx, idx) | Bytecode::PopLocal(up_idx, idx) => {
+                print!(" {up_idx}, {idx}");
+                let maybe_local = (env.iter().rev().nth(usize::from(up_idx)))
+                    .and_then(|env| env.resolve_local(idx));
+                let Some(local) = maybe_local else {
+                    println!(" (invalid local)");
+                    continue;
+                };
+                println!(" (`{0}`)", universe.lookup_symbol(local));
+            }
+            Bytecode::PushField(idx) | Bytecode::PopField(idx) => {
+                print!(" {idx}");
+                let Some((name, _)) = class.locals.get_index(usize::from(idx)) else {
+                    println!(" (invalid field)");
+                    continue;
+                };
+                println!(" (`{0}`)", universe.lookup_symbol(*name));
+            }
+            Bytecode::PushArgument(up_idx, idx) => {
+                println!(" {up_idx}, {idx}");
+            }
+            Bytecode::PushBlock(idx) => {
+                println!(" {idx}");
+                let Some(Literal::Block(blk)) = current.resolve_literal(idx) else {
+                    println!("{padding}  | (invalid block)");
+                    continue;
+                };
+                env.push(blk.as_ref());
+                disassemble_body(universe, class, level + 1, env);
+                env.pop();
+            }
+            Bytecode::PushConstant(idx) => {
+                print!(" {idx}");
+                let Some(literal) = current.resolve_literal(idx) else {
+                    println!(" (invalid constant)");
+                    continue;
+                };
+                match literal {
+                    Literal::Symbol(symbol) => {
+                        println!(" (Symbol(#{0}))", universe.lookup_symbol(*symbol));
+                    }
+                    _ => {
+                        println!(" ({literal:?})");
+                    }
+                }
+            }
+            Bytecode::PushGlobal(idx) => {
+                print!(" {idx}");
+                let Some(Literal::Symbol(signature)) = current.resolve_literal(idx) else {
+                    println!(" (invalid global)");
+                    continue;
+                };
+                println!(" (`{0}`)", universe.lookup_symbol(*signature));
+            }
+            Bytecode::Pop => {
+                println!();
+            }
+            Bytecode::PopArgument(up_idx, idx) => {
+                print!(" {up_idx}, {idx}");
+                // TODO: the following requires to change the parser and interpreter to preserve argument names.
+                // let maybe_argument = (env.iter().rev().nth(usize::from(up_idx)))
+                //     .and_then(|env| env.resolve_argument(idx));
+                // let Some(argument) = maybe_argument else {
+                //     println!(" (invalid argument)");
+                //     continue;
+                // };
+                // println!(" (`{0}`)", universe.lookup_symbol(argument));
+            }
+            Bytecode::Send(idx) | Bytecode::SuperSend(idx) => {
+                print!(" {idx}");
+                let Some(Literal::Symbol(signature)) = current.resolve_literal(idx) else {
+                    println!(" (invalid signature)");
+                    continue;
+                };
+                println!(" (#{0})", universe.lookup_symbol(*signature));
+            }
+            Bytecode::ReturnLocal => {
+                println!();
+            }
+            Bytecode::ReturnNonLocal => {
+                println!();
+            }
+        }
+    }
+}
+
+trait FrameEnv {
+    fn get_body(&self) -> &[Bytecode];
+    fn resolve_local(&self, idx: u8) -> Option<Interned>;
+    fn resolve_literal(&self, idx: u8) -> Option<&Literal>;
+    fn resolve_argument(&self, idx: u8) -> Option<Interned>;
+}
+
+impl FrameEnv for MethodEnv {
+    fn get_body(&self) -> &[Bytecode] {
+        &self.body
+    }
+
+    fn resolve_local(&self, idx: u8) -> Option<Interned> {
+        self.locals.get(usize::from(idx)).copied()
+    }
+
+    fn resolve_literal(&self, idx: u8) -> Option<&Literal> {
+        self.literals.get(usize::from(idx))
+    }
+
+    fn resolve_argument(&self, _idx: u8) -> Option<Interned> {
+        todo!()
+    }
+}
+
+impl FrameEnv for Block {
+    fn get_body(&self) -> &[Bytecode] {
+        &self.blk_info.body
+    }
+
+    fn resolve_local(&self, idx: u8) -> Option<Interned> {
+        self.blk_info.locals.get(usize::from(idx)).copied()
+    }
+
+    fn resolve_literal(&self, idx: u8) -> Option<&Literal> {
+        self.blk_info.literals.get(usize::from(idx))
+    }
+
+    fn resolve_argument(&self, _idx: u8) -> Option<Interned> {
+        todo!()
+    }
+}

--- a/som-interpreter-bc/src/lib.rs
+++ b/som-interpreter-bc/src/lib.rs
@@ -11,6 +11,8 @@ pub mod block;
 pub mod class;
 /// Facilities for compiling code into bytecode.
 pub mod compiler;
+/// Facilities for disassembling bytecode.
+pub mod disassembler;
 /// Facilities for manipulating stack frames.
 pub mod frame;
 /// Facilities for manipulating values.

--- a/som-interpreter-bc/src/main.rs
+++ b/som-interpreter-bc/src/main.rs
@@ -6,14 +6,16 @@
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use anyhow::anyhow;
+use anyhow::{bail, Context};
 #[cfg(feature = "jemalloc")]
 use jemallocator::Jemalloc;
 use structopt::StructOpt;
 
 mod shell;
 
+use som_interpreter_bc::disassembler::disassemble_method_body;
 use som_interpreter_bc::interpreter::Interpreter;
+use som_interpreter_bc::method::{Method, MethodKind};
 use som_interpreter_bc::universe::Universe;
 use som_interpreter_bc::value::Value;
 
@@ -24,20 +26,20 @@ static GLOBAL: Jemalloc = Jemalloc;
 #[derive(Debug, Clone, PartialEq, StructOpt)]
 #[structopt(about, author)]
 struct Options {
-    /// Files to evaluate.
-    #[structopt(name = "FILE")]
+    /// File to evaluate.
     file: Option<PathBuf>,
 
-    #[structopt(name = "ARGS")]
+    /// Arguments to pass to the `#run:` function.
     args: Vec<String>,
 
     /// Set search path for application classes.
-    #[structopt(short, long)]
+    #[structopt(long, short)]
     classpath: Vec<PathBuf>,
 
-    // /// enable disassembling
-    // #[structopt(short = "d")]
-    // disassembling: bool,
+    /// Disassemble the class, instead of executing.
+    #[structopt(long, short)]
+    disassemble: bool,
+
     /// Enable verbose output (with timing information).
     #[structopt(short = "v")]
     verbose: bool,
@@ -48,62 +50,120 @@ fn main() -> anyhow::Result<()> {
 
     let mut interpreter = Interpreter::new();
 
-    match opts.file {
-        None => {
-            let mut universe = Universe::with_classpath(opts.classpath)?;
-            shell::interactive(&mut interpreter, &mut universe, opts.verbose)?
-        }
-        Some(file) => {
-            let file_stem = file
-                .file_stem()
-                .ok_or_else(|| anyhow!("the given path has no file stem"))?;
-            let file_stem = file_stem
-                .to_str()
-                .ok_or_else(|| anyhow!("the given path contains invalid UTF-8 in its file stem"))?;
+    if opts.disassemble {
+        return disassemble_class(opts);
+    }
 
-            let mut classpath = opts.classpath;
-            if let Some(directory) = file.parent() {
-                classpath.push(directory.to_path_buf());
+    let Some(file) = opts.file else {
+        let mut universe = Universe::with_classpath(opts.classpath)?;
+        return shell::interactive(&mut interpreter, &mut universe, opts.verbose);
+    };
+
+    let file_stem = file
+        .file_stem()
+        .context("the given path has no file stem")?
+        .to_str()
+        .context("the given path contains invalid UTF-8 in its file stem")?;
+
+    let mut classpath = opts.classpath;
+    if let Some(directory) = file.parent() {
+        classpath.push(directory.to_path_buf());
+    }
+
+    let mut universe = Universe::with_classpath(classpath)?;
+
+    let args = std::iter::once(String::from(file_stem))
+        .chain(opts.args.iter().cloned())
+        .map(Rc::new)
+        .map(Value::String)
+        .collect();
+
+    universe
+        .initialize(&mut interpreter, args)
+        .expect("issue running program");
+
+    interpreter.run(&mut universe);
+
+    // let class = universe.load_class_from_path(file)?;
+    // let instance = som_interpreter::instance::Instance::from_class(class);
+    // let instance = Value::Instance(Rc::new(std::cell::RefCell::new(instance)));
+
+    // let invokable = instance.lookup_method(&universe, "run").unwrap();
+    // let output = som_interpreter::invokable::Invoke::invoke(invokable.as_ref(), &mut universe, vec![instance]);
+
+    // match output {
+    //     Return::Exception(message) => println!("ERROR: {}", message),
+    //     Return::Restart => println!("ERROR: asked for a restart to the top-level"),
+    //     _ => {}
+    // }
+
+    Ok(())
+}
+
+fn disassemble_class(opts: Options) -> anyhow::Result<()> {
+    let Some(file) = opts.file else {
+        bail!("no class specified for disassembly");
+    };
+
+    let file_stem = file
+        .file_stem()
+        .context("the given path has no file stem")?
+        .to_str()
+        .context("the given path contains invalid UTF-8 in its file stem")?;
+
+    let mut classpath = opts.classpath;
+    if let Some(directory) = file.parent() {
+        classpath.push(directory.to_path_buf());
+    }
+    let mut universe = Universe::with_classpath(classpath)?;
+
+    let class = universe.load_class(file_stem)?;
+
+    let methods: Vec<Rc<Method>> = if opts.args.is_empty() {
+        class.borrow().methods.values().cloned().collect()
+    } else {
+        opts.args
+            .iter()
+            .filter_map(|signature| {
+                let symbol = universe.intern_symbol(signature);
+                let maybe_method = class.borrow().methods.get(&symbol).cloned();
+
+                if maybe_method.is_none() {
+                    eprintln!("No method named `{signature}` found in class `{file_stem}`.");
+                }
+
+                maybe_method
+            })
+            .collect()
+    };
+
+    for method in methods {
+        match &method.kind {
+            MethodKind::Defined(env) => {
+                println!(
+                    "{class}>>#{signature} ({num_locals} locals, {num_literals} literals)",
+                    class = file_stem,
+                    signature = method.signature(),
+                    num_locals = env.locals.len(),
+                    num_literals = env.literals.len(),
+                );
+
+                disassemble_method_body(&universe, &class.borrow(), env);
             }
-
-            let mut universe = Universe::with_classpath(classpath)?;
-
-            // let class = universe.load_class("System");
-            // if let Ok(class) = class {
-            //     for method in class.borrow().methods.values() {
-            //         println!("System>>#{}", method.signature);
-            //         if let som_interpreter_bc::method::MethodKind::Defined(env) = &method.kind {
-            //             for bytecode in &env.body {
-            //                 println!("    {}", bytecode);
-            //             }
-            //         }
-            //     }
-            // }
-
-            let args = std::iter::once(String::from(file_stem))
-                .chain(opts.args.iter().cloned())
-                .map(Rc::new)
-                .map(Value::String)
-                .collect();
-
-            universe
-                .initialize(&mut interpreter, args)
-                .expect("issue running program");
-
-            interpreter.run(&mut universe);
-
-            // let class = universe.load_class_from_path(file)?;
-            // let instance = som_interpreter::instance::Instance::from_class(class);
-            // let instance = Value::Instance(Rc::new(std::cell::RefCell::new(instance)));
-
-            // let invokable = instance.lookup_method(&universe, "run").unwrap();
-            // let output = som_interpreter::invokable::Invoke::invoke(invokable.as_ref(), &mut universe, vec![instance]);
-
-            // match output {
-            //     Return::Exception(message) => println!("ERROR: {}", message),
-            //     Return::Restart => println!("ERROR: asked for a restart to the top-level"),
-            //     _ => {}
-            // }
+            MethodKind::Primitive(_) => {
+                println!(
+                    "{class}>>#{signature} (primitive)",
+                    class = file_stem,
+                    signature = method.signature(),
+                );
+            }
+            MethodKind::NotImplemented(_) => {
+                println!(
+                    "{class}>>#{signature} (not implemented)",
+                    class = file_stem,
+                    signature = method.signature(),
+                );
+            }
         }
     }
 

--- a/som-interpreter-bc/src/method.rs
+++ b/som-interpreter-bc/src/method.rs
@@ -7,6 +7,7 @@ use som_core::bytecode::Bytecode;
 use crate::class::Class;
 use crate::compiler::Literal;
 use crate::frame::FrameKind;
+use crate::interner::Interned;
 use crate::interpreter::Interpreter;
 use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
@@ -15,7 +16,7 @@ use crate::{SOMRef, SOMWeakRef};
 
 #[derive(Clone)]
 pub struct MethodEnv {
-    pub locals: Vec<Value>,
+    pub locals: Vec<Interned>,
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
     pub inline_cache: RefCell<Vec<Option<(*const Class, Rc<Method>)>>>,


### PR DESCRIPTION
This PR adds support for a new `-d` (or `--disassemble`) flag for disassembling the methods for a specified class.  

Using this flag prints out the bytecode contents of every (or only some if specified) methods of the specified class and exits, instead of normal bytecode execution.

This can be useful when looking for optimisable repeating patterns in the generated bytecode.

Example usage (which has been added in the README as well):
```bash
./target/release/som-interpreter-bc -c core-lib/Smalltalk -d core-lib/Examples/Hello.som
# OR:
./target/release/som-interpreter-bc -c core-lib/Smalltalk core-lib/Examples -d Hello
# OR (for disassembling only specific methods):
./target/release/som-interpreter-bc -c core-lib/Smalltalk core-lib/Examples -d Hello first:method: second:method:
```