### PR TITLE
Symmetric `String`/`Symbol` equality

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -18,7 +18,7 @@ runs:
 benchmark_suites:
     macro:
         gauge_adapter: RebenchLog
-        command: &MACRO_CMD "-c core-lib/Smalltalk core-lib/Examples/Benchmarks core-lib/Examples/Benchmarks/Richards core-lib/Examples/Benchmarks/DeltaBlue core-lib/Examples/Benchmarks/NBody core-lib/Examples/Benchmarks/Json core-lib/Examples/Benchmarks/GraphSearch -- BenchmarkHarness %(benchmark)s %(iterations)s 0 "
+        command: &MACRO_CMD "-c core-lib/Smalltalk core-lib/Examples/Benchmarks core-lib/Examples/Benchmarks/Richards core-lib/Examples/Benchmarks/DeltaBlue core-lib/Examples/Benchmarks/NBody core-lib/Examples/Benchmarks/Json core-lib/Examples/Benchmarks/GraphSearch -- BenchmarkHarness %(benchmark)s %(iterations)s "
         iterations: 10
         benchmarks:
             - Richards:     {extra_args: 1}
@@ -30,7 +30,7 @@ benchmark_suites:
 
     micro:
         gauge_adapter: RebenchLog
-        command: "-c core-lib/Smalltalk core-lib/Examples/Benchmarks core-lib/Examples/Benchmarks/LanguageFeatures -- BenchmarkHarness %(benchmark)s %(iterations)s 0 "
+        command: "-c core-lib/Smalltalk core-lib/Examples/Benchmarks core-lib/Examples/Benchmarks/LanguageFeatures -- BenchmarkHarness %(benchmark)s %(iterations)s "
         iterations: 10
         benchmarks:
             - Fannkuch:     {extra_args: 6}

--- a/som-interpreter-ast/src/primitives/symbol.rs
+++ b/som-interpreter-ast/src/primitives/symbol.rs
@@ -7,7 +7,7 @@ use crate::universe::Universe;
 use crate::value::Value;
 
 pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] =
-    &[("asString", self::as_string, true), ("=", self::eq, false)];
+    &[("asString", self::as_string, true)];
 pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
 fn as_string(universe: &mut Universe, args: Vec<Value>) -> Return {
@@ -20,17 +20,6 @@ fn as_string(universe: &mut Universe, args: Vec<Value>) -> Return {
     Return::Local(Value::String(Rc::new(
         universe.lookup_symbol(sym).to_string(),
     )))
-}
-
-fn eq(_: &mut Universe, args: Vec<Value>) -> Return {
-    const SIGNATURE: &str = "Symbol>>#=";
-
-    expect_args!(SIGNATURE, args, [
-        sym @ Value::Symbol(_) => sym,
-        other => other,
-    ]);
-
-    Return::Local(Value::Boolean(sym == other))
 }
 
 /// Search for an instance primitive matching the given signature.

--- a/som-interpreter-bc/src/primitives/symbol.rs
+++ b/som-interpreter-bc/src/primitives/symbol.rs
@@ -7,7 +7,7 @@ use crate::value::Value;
 use crate::{expect_args, reverse};
 
 pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] =
-    &[("asString", self::as_string, true), ("=", self::eq, false)];
+    &[("asString", self::as_string, true)];
 pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
 fn as_string(interpreter: &mut Interpreter, universe: &mut Universe) {
@@ -20,17 +20,6 @@ fn as_string(interpreter: &mut Interpreter, universe: &mut Universe) {
     interpreter.stack.push(Value::String(Rc::new(
         universe.lookup_symbol(sym).to_string(),
     )));
-}
-
-fn eq(interpreter: &mut Interpreter, _: &mut Universe) {
-    const SIGNATURE: &str = "Symbol>>#=";
-
-    expect_args!(SIGNATURE, interpreter, [
-        sym @ Value::Symbol(_) => sym,
-        other => other,
-    ]);
-
-    interpreter.stack.push(Value::Boolean(sym == other));
 }
 
 /// Search for an instance primitive matching the given signature.


### PR DESCRIPTION
This PR removes the `Symbol>>#=` primitive which made the `=` operator to be non-symmetric with regards to `String`.  

The `String>>#=` compares the string contents of both arguments for equality, while `Symbol>>#=` was looking for strict equality, meaning both arguments also had to be instances of `Symbol`.
Now, because `Symbol` is a subclass of `String`, both types are now compared solely on their string contents (using `String>>#=`).  

This PR is made in anticipation of the corresponding PR in the SOM core library ([**som-st/SOM#106**](https://github.com/SOM-st/SOM/pull/106)).

**Depends on [som-st/SOM#106](https://github.com/SOM-st/SOM/pull/106).**