### PR TITLE
Fixes for ReBench benchmarks

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -7,7 +7,7 @@ reporting:
     # Benchmark results will be reported to ReBenchDB
     rebenchdb:
         # this url needs to point to the API endpoint
-        db_url: https://rebench.polomack.eu/rebenchdb/results
+        db_url: https://rebench.polomack.eu/rebenchdb
         repo_url: https://github.com/Hirevo/som-rs
         record_all: true # make sure everything is recorded
         project_name: som-rs


### PR DESCRIPTION
The goal of this PR is to bring the ReBench setup up to date and have it running again, because quite a bit of time passed since I last updated the ReBench instance.  