### PR TITLE
Accept proper identifiers as symbols

### DIFF
--- a/som-lexer/src/lexer.rs
+++ b/som-lexer/src/lexer.rs
@@ -177,7 +177,7 @@ impl Iterator for Lexer {
                     }
                     Some(ch) if ch.is_alphabetic() => {
                         let len = iter
-                            .take_while(|ch| ch.is_alphabetic() || matches!(*ch, ':' | '_'))
+                            .take_while(|ch| ch.is_alphanumeric() || matches!(*ch, ':' | '_'))
                             .count();
                         let mut symbol = String::with_capacity(len);
                         self.chars.pop()?;


### PR DESCRIPTION
This PR fixes the bug found in [**som-st/SOM#110**](https://github.com/SOM-st/SOM/pull/110), where the lexer would not accept digits anywhere within the identifier following an `#`.  

As an example, `#foo42` was incorrectly tokenized as `[Token::Symbol("foo"), Token::Integer(42)]`.

Now, the lexer parses it properly as `Token::Symbol("foo42")`, with the same rules as any identifier (essentially `[A-Za-z][A-Za-z0-9_:]*`).