### PR TITLE
Feature flag to compile using `jemalloc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cc"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +66,12 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "getrandom"
@@ -104,6 +116,27 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.2+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134163979b6eed9564c98637b710b40979939ba351f59952708234ea11b5f3f8"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
 ]
 
 [[package]]
@@ -246,6 +279,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "indexmap",
+ "jemallocator",
  "num-bigint",
  "num-traits",
  "rand",
@@ -261,6 +295,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "indexmap",
+ "jemallocator",
  "num-bigint",
  "num-traits",
  "rand",

--- a/som-interpreter-ast/Cargo.toml
+++ b/som-interpreter-ast/Cargo.toml
@@ -29,3 +29,9 @@ num-traits = "0.2.14"
 
 # random numbers
 rand = "0.8.4"
+
+# global allocator
+jemallocator = { version = "0.5.0", optional = true }
+
+[features]
+jemalloc = ["jemallocator"]

--- a/som-interpreter-ast/src/main.rs
+++ b/som-interpreter-ast/src/main.rs
@@ -7,6 +7,8 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use anyhow::anyhow;
+#[cfg(feature = "jemalloc")]
+use jemallocator::Jemalloc;
 use structopt::StructOpt;
 
 mod shell;
@@ -14,6 +16,10 @@ mod shell;
 use som_interpreter_ast::invokable::Return;
 use som_interpreter_ast::universe::Universe;
 use som_interpreter_ast::value::Value;
+
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(Debug, Clone, PartialEq, StructOpt)]
 #[structopt(about, author)]

--- a/som-interpreter-bc/Cargo.toml
+++ b/som-interpreter-bc/Cargo.toml
@@ -29,3 +29,9 @@ num-traits = "0.2.14"
 
 # random numbers
 rand = "0.8.4"
+
+# global allocator
+jemallocator = { version = "0.5.0", optional = true }
+
+[features]
+jemalloc = ["jemallocator"]

--- a/som-interpreter-bc/src/main.rs
+++ b/som-interpreter-bc/src/main.rs
@@ -7,6 +7,8 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use anyhow::anyhow;
+#[cfg(feature = "jemalloc")]
+use jemallocator::Jemalloc;
 use structopt::StructOpt;
 
 mod shell;
@@ -14,6 +16,10 @@ mod shell;
 use som_interpreter_bc::interpreter::Interpreter;
 use som_interpreter_bc::universe::Universe;
 use som_interpreter_bc::value::Value;
+
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(Debug, Clone, PartialEq, StructOpt)]
 #[structopt(about, author)]


### PR DESCRIPTION
This PR adds support for a new compile-time feature flag `jemalloc`, which enables the use of `jemalloc` as the global memory allocator, instead of the default system allocator.  

This feature flag is made available for both the AST and bytecode interpreters.  

Here is how to compile using this feature:
```bash
# this will compile both interpreters with the `jemalloc` feature
cargo build --release --features 'jemalloc'

# this will only compile `som-interpreter-bc` specifically with the `jemalloc` feature
cargo build --release -p som-interpreter-bc --features 'jemalloc'
```