### PR TITLE
(opt): Multiple inline cache slots per call-site

### DIFF
--- a/som-interpreter-bc/src/block.rs
+++ b/som-interpreter-bc/src/block.rs
@@ -21,7 +21,7 @@ pub struct Block {
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
     pub nb_params: usize,
-    pub inline_cache: Rc<RefCell<Vec<Option<(*const Class, Rc<Method>)>>>>,
+    pub inline_cache: Rc<RefCell<Vec<[Option<(*const Class, Rc<Method>)>; 3]>>>,
 }
 
 impl Block {

--- a/som-interpreter-bc/src/compiler.rs
+++ b/som-interpreter-bc/src/compiler.rs
@@ -414,7 +414,11 @@ fn compile_method(outer: &mut dyn GenCtxt, defn: &ast::MethodDef) -> Option<Meth
                 let body = ctxt.inner.body.unwrap_or_default();
                 let locals = ctxt.inner.locals.iter().map(|_| Value::Nil).collect();
                 let literals = ctxt.inner.literals.into_iter().collect();
-                let inline_cache = RefCell::new(vec![None; body.len()]);
+                let inline_cache = RefCell::new(
+                    std::iter::repeat_with(|| Default::default())
+                        .take(body.len())
+                        .collect(),
+                );
 
                 MethodKind::Defined(MethodEnv {
                     body,
@@ -459,7 +463,11 @@ fn compile_block(outer: &mut dyn GenCtxt, defn: &ast::Block) -> Option<Block> {
     let literals = ctxt.literals.into_iter().collect();
     let body = ctxt.body.unwrap_or_default();
     let nb_params = ctxt.args.len();
-    let inline_cache = Rc::new(RefCell::new(vec![None; body.len()]));
+    let inline_cache = Rc::new(RefCell::new(
+        std::iter::repeat_with(|| Default::default())
+            .take(body.len())
+            .collect(),
+    ));
 
     let block = Block {
         frame,

--- a/som-interpreter-bc/src/interpreter.rs
+++ b/som-interpreter-bc/src/interpreter.rs
@@ -335,10 +335,16 @@ impl Interpreter {
                     let maybe_found = unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
 
                     match maybe_found {
-                        Some((receiver, method)) if *receiver == class.as_ptr() => {
+                        [Some((receiver, method)), _, _] if *receiver == class.as_ptr() => {
                             Some(Rc::clone(method))
                         }
-                        place @ None => {
+                        [_, Some((receiver, method)), _] if *receiver == class.as_ptr() => {
+                            Some(Rc::clone(method))
+                        }
+                        [_, _, Some((receiver, method))] if *receiver == class.as_ptr() => {
+                            Some(Rc::clone(method))
+                        }
+                        [place @ None, _, _] | [_, place @ None, _] | [_, _, place @ None] => {
                             let found = class.borrow().lookup_method(signature);
                             *place = found
                                 .clone()
@@ -358,10 +364,16 @@ impl Interpreter {
                         let maybe_found = unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
 
                         match maybe_found {
-                            Some((receiver, method)) if *receiver == class.as_ptr() => {
+                            [Some((receiver, method)), _, _] if *receiver == class.as_ptr() => {
                                 Some(Rc::clone(method))
                             }
-                            place @ None => {
+                            [_, Some((receiver, method)), _] if *receiver == class.as_ptr() => {
+                                Some(Rc::clone(method))
+                            }
+                            [_, _, Some((receiver, method))] if *receiver == class.as_ptr() => {
+                                Some(Rc::clone(method))
+                            }
+                            [place @ None, _, _] | [_, place @ None, _] | [_, _, place @ None] => {
                                 let found = class.borrow().lookup_method(signature);
                                 *place = found
                                     .clone()

--- a/som-interpreter-bc/src/method.rs
+++ b/som-interpreter-bc/src/method.rs
@@ -18,7 +18,7 @@ pub struct MethodEnv {
     pub locals: Vec<Value>,
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
-    pub inline_cache: RefCell<Vec<Option<(*const Class, Rc<Method>)>>>,
+    pub inline_cache: RefCell<Vec<[Option<(*const Class, Rc<Method>)>; 3]>>,
 }
 
 /// The kind of a class method.


### PR DESCRIPTION
This PR follows the work done in **#13** to improve the performance of message sends using inline caches for method lookups.  

The current implementation uses a single never-evicted cache slot per call-site for the inline caches, which was a notable performance improvement compared to not using any cache at all.  

This PR experiments with adding more cache slots per call-site (currently: 3 slots per call-site), with the goal of further improve method dispatch performance.  

The initial performance assessment is that, in this current state, the additional slots do not measurably improve performance.  

For reference, here are the benchmarking numbers that led to this conclusion:

![image](https://user-images.githubusercontent.com/4294633/215089742-451b29f3-bf15-427c-a0dc-23b1922903fd.png)

The goal of this PR is to continue exploring how to potentially improve the implementation to make better use of these additional cache slots.