### PR TITLE
`som-gc`: Custom Mark-and-Sweep Garbage Collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,10 @@ name = "som-core"
 version = "0.1.0"
 
 [[package]]
+name = "som-gc"
+version = "0.1.0"
+
+[[package]]
 name = "som-interpreter-ast"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "num-traits",
  "rand",
  "som-core",
+ "som-gc",
  "som-lexer",
  "som-parser-symbols",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "som-parser-core",
     "som-parser-symbols",
     "som-parser-text",
+    "som-gc",
 ]
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Here is a rundown of these different crates (as of now, layout may change in the
 | **`som-parser-core`**     | The common foundational types for building parsers            |
 | **`som-parser-text`**     | A SOM parser that works directly with text (without a lexer). |
 | **`som-parser-symbols`**  | A SOM parser that works with **`som-lexer`**'s output.        |
+| **`som-gc`**              | The SOM mark-and-sweep garbage collector as a library.        |
 
 [**Cargo workspace**]: https://doc.rust-lang.org/cargo/reference/workspaces.html
 

--- a/som-gc/Cargo.toml
+++ b/som-gc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "som-gc"
+version = "0.1.0"
+description = "A garbage collector for the Simple Object Machine"
+authors = ["Nicolas Polomack <nmp21@kent.ac.uk>"]
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"

--- a/som-gc/README.md
+++ b/som-gc/README.md
@@ -1,0 +1,4 @@
+The SOM Garbage Collector
+=========================
+
+This is the mark-and-sweep garbage collector implementation for `som-rs`.

--- a/som-gc/src/gc.rs
+++ b/som-gc/src/gc.rs
@@ -2,10 +2,8 @@ use std::borrow::Borrow;
 use std::cell::Cell;
 use std::fmt;
 use std::hash::Hash;
-use std::marker::PhantomData;
 use std::ops::Deref;
 use std::ptr::NonNull;
-use std::rc::Rc;
 
 use crate::gc_box::GcBox;
 use crate::trace::Trace;
@@ -17,8 +15,6 @@ where
 {
     /// The pointer to the referenced `GcBox<T>`.
     pub(crate) ptr: Cell<NonNull<GcBox<T>>>,
-    // needed for drop-related reasons.
-    pub(crate) marker: PhantomData<Rc<T>>,
 }
 
 impl<T> Gc<T>
@@ -141,7 +137,6 @@ where
     fn clone(&self) -> Self {
         Self {
             ptr: self.ptr.clone(),
-            marker: PhantomData,
         }
     }
 }

--- a/som-gc/src/gc.rs
+++ b/som-gc/src/gc.rs
@@ -1,0 +1,55 @@
+use std::cell::Cell;
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::ptr::NonNull;
+use std::rc::Rc;
+
+use crate::gc_box::GcBox;
+use crate::trace::Trace;
+
+/// Represent a handle to a GC-allocated value.
+pub struct Gc<T>
+where
+    T: Trace + 'static,
+{
+    /// The pointer to the referenced `GcBox<T>`.
+    pub(crate) ptr: Cell<NonNull<GcBox<T>>>,
+    // needed for drop-related reasons.
+    pub(crate) marker: PhantomData<Rc<T>>,
+}
+
+impl<T> Clone for Gc<T>
+where
+    T: Trace + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            ptr: self.ptr.clone(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Trace for Gc<T>
+where
+    T: Trace + 'static,
+{
+    fn trace(&self) {
+        let ptr = unsafe { self.ptr.get().as_mut() };
+        if !ptr.is_marked() {
+            ptr.mark();
+            ptr.value.trace();
+        }
+    }
+}
+
+impl<T> Deref for Gc<T>
+where
+    T: Trace + 'static,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.ptr.get().as_ref() }
+    }
+}

--- a/som-gc/src/gc.rs
+++ b/som-gc/src/gc.rs
@@ -1,4 +1,7 @@
+use std::borrow::Borrow;
 use std::cell::Cell;
+use std::fmt;
+use std::hash::Hash;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::ptr::NonNull;
@@ -18,10 +21,123 @@ where
     pub(crate) marker: PhantomData<Rc<T>>,
 }
 
+impl<T> Gc<T>
+where
+    T: Trace + 'static,
+{
+    #[inline]
+    pub fn as_mut_ptr(&self) -> *const T {
+        unsafe { &mut self.ptr.get().as_mut().value as *mut T }
+    }    
+
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        unsafe { &self.ptr.get().as_ref().value as *const T }
+    }
+
+    #[inline]
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        self.ptr == other.ptr
+    }
+}
+
+impl<T> Gc<T>
+where
+    T: Deref + Trace + 'static,
+{
+    #[inline]
+    pub fn as_deref(&self) -> &T::Target {
+        &**self
+    }
+}
+
+impl<T> fmt::Debug for Gc<T>
+where
+    T: fmt::Debug + Trace + 'static,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_ref().fmt(f)
+    }
+}
+
+impl<T> fmt::Display for Gc<T>
+where
+    T: fmt::Display + Trace + 'static,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_ref().fmt(f)
+    }
+}
+
+impl<T> PartialEq for Gc<T>
+where
+    T: PartialEq + Trace + 'static,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl<T> Eq for Gc<T> where T: Eq + Trace + 'static {}
+
+impl<T> Hash for Gc<T>
+where
+    T: Hash + Trace + 'static,
+{
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state)
+    }
+}
+
+impl<T> PartialOrd for Gc<T>
+where
+    T: PartialOrd + Trace + 'static,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.as_ref().partial_cmp(other.as_ref())
+    }
+}
+
+impl<T> Ord for Gc<T>
+where
+    T: Ord + Trace + 'static,
+{
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_ref().cmp(other.as_ref())
+    }
+}
+
+impl<T> Borrow<T> for Gc<T>
+where
+    T: Trace + 'static,
+{
+    #[inline]
+    fn borrow(&self) -> &T {
+        &*self
+    }
+}
+
+impl<T> AsRef<T> for Gc<T>
+where
+    T: Trace + 'static,
+{
+    #[inline]
+    fn as_ref(&self) -> &T {
+        &*self
+    }
+}
+
 impl<T> Clone for Gc<T>
 where
     T: Trace + 'static,
 {
+    #[inline]
     fn clone(&self) -> Self {
         Self {
             ptr: self.ptr.clone(),
@@ -34,6 +150,7 @@ impl<T> Trace for Gc<T>
 where
     T: Trace + 'static,
 {
+    #[inline]
     fn trace(&self) {
         let ptr = unsafe { self.ptr.get().as_mut() };
         if !ptr.is_marked() {
@@ -49,6 +166,7 @@ where
 {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         unsafe { self.ptr.get().as_ref() }
     }

--- a/som-gc/src/gc.rs
+++ b/som-gc/src/gc.rs
@@ -28,7 +28,7 @@ where
     #[inline]
     pub fn as_mut_ptr(&self) -> *const T {
         unsafe { &mut self.ptr.get().as_mut().value as *mut T }
-    }    
+    }
 
     #[inline]
     pub fn as_ptr(&self) -> *const T {

--- a/som-gc/src/gc_box.rs
+++ b/som-gc/src/gc_box.rs
@@ -1,5 +1,5 @@
-use std::ops::{Deref, DerefMut};
 use std::cell::Cell;
+use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
 use crate::Trace;

--- a/som-gc/src/gc_box.rs
+++ b/som-gc/src/gc_box.rs
@@ -1,15 +1,11 @@
 use std::cell::Cell;
 use std::ops::{Deref, DerefMut};
-use std::ptr::NonNull;
-
-use crate::Trace;
 
 /// Represents a value, as it is stored within the GC.
 #[repr(C)]
 pub(crate) struct GcBox<T: ?Sized> {
     /// Pointer to next value in the GC chain.  
     pub(crate) marked: Cell<bool>,
-    pub(crate) next: Option<NonNull<GcBox<dyn Trace + 'static>>>,
     pub(crate) value: T,
 }
 
@@ -19,7 +15,6 @@ impl<T> GcBox<T> {
     pub fn new(value: T) -> Self {
         Self {
             marked: Cell::new(false),
-            next: None,
             value,
         }
     }
@@ -50,7 +45,6 @@ impl<T: Default> Default for GcBox<T> {
     fn default() -> Self {
         Self {
             marked: Cell::new(false),
-            next: None,
             value: T::default(),
         }
     }

--- a/som-gc/src/gc_box.rs
+++ b/som-gc/src/gc_box.rs
@@ -5,6 +5,7 @@ use std::ptr::NonNull;
 use crate::Trace;
 
 /// Represents a value, as it is stored within the GC.
+#[repr(C)]
 pub(crate) struct GcBox<T: ?Sized> {
     /// Pointer to next value in the GC chain.  
     pub(crate) marked: Cell<bool>,
@@ -14,6 +15,7 @@ pub(crate) struct GcBox<T: ?Sized> {
 
 impl<T> GcBox<T> {
     /// Creates a singleton `GcBox` value (which isn't part of any chain yet).
+    #[inline]
     pub fn new(value: T) -> Self {
         Self {
             marked: Cell::new(false),
@@ -25,22 +27,26 @@ impl<T> GcBox<T> {
 
 impl<T: ?Sized> GcBox<T> {
     /// Clears the `mark` bit for this GC object.
+    #[inline]
     pub fn clear_mark(&mut self) {
         self.marked.set(false);
     }
 
     /// Sets the `mark` bit for this GC object.
+    #[inline]
     pub fn mark(&mut self) {
         self.marked.set(true);
     }
 
     /// Returns whether the `mark` bit is set for this GC object.
+    #[inline]
     pub fn is_marked(&self) -> bool {
         self.marked.get()
     }
 }
 
 impl<T: Default> Default for GcBox<T> {
+    #[inline]
     fn default() -> Self {
         Self {
             marked: Cell::new(false),
@@ -53,12 +59,14 @@ impl<T: Default> Default for GcBox<T> {
 impl<T> Deref for GcBox<T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.value
     }
 }
 
 impl<T> DerefMut for GcBox<T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.value
     }

--- a/som-gc/src/gc_box.rs
+++ b/som-gc/src/gc_box.rs
@@ -1,0 +1,76 @@
+use std::ops::{Deref, DerefMut};
+
+/// Represents a value, as it is stored within the GC.
+pub(crate) struct GcBox<T> {
+    /// Pointer to next value in the GC chain.  
+    ///
+    /// We also use the unused bits of this pointer to store the `marked` bitflag.  
+    /// Therefore, it not suitable for it to be dereferenced as-is, it must first
+    /// be cleared of these flags before any accesses are performed.  
+    /// This is also why this is not represented as a `Option<NonNull<GcBox<T>>>`
+    pub(crate) next: *mut GcBox<T>,
+    pub(crate) value: T,
+}
+
+impl<T> GcBox<T> {
+    /// Bitflag for whether the current GC object is marked (still referenced).
+    pub const MARK_BITMASK: usize = 0b0000_0001;
+    /// Bitmask for the bits reserved for GC flags within the `next` pointer in `GcBox`.
+    pub const FLAGS_BITMASK: usize = 0b0000_0011;
+
+    /// Creates a singleton `GcBox` value (which isn't part of any chain yet).
+    pub fn new(value: T) -> Self {
+        Self {
+            next: std::ptr::null_mut(),
+            value,
+        }
+    }
+
+    /// Clears the `mark` bit for this GC object.
+    pub fn clear_mark(&mut self) {
+        self.next = (self.next as usize & !Self::MARK_BITMASK) as *mut _;
+    }
+
+    /// Sets the `mark` bit for this GC object.
+    pub fn mark(&mut self) {
+        self.next = (self.next as usize | Self::MARK_BITMASK) as *mut _;
+    }
+
+    /// Returns whether the `mark` bit is set for this GC object.
+    pub fn is_marked(&self) -> bool {
+        self.next as usize & Self::MARK_BITMASK == 1
+    }
+
+    /// Returns the pointer to the next GC object in the chain.
+    pub fn next(&self) -> *mut GcBox<T> {
+        (self.next as usize & !Self::FLAGS_BITMASK) as *mut _
+    }
+
+    /// Sets the pointer to the next GC object in the chain, and preserving all the current bitflags.
+    pub fn set_next(&mut self, next: *mut GcBox<T>) {
+        self.next = (next as usize | (self.next as usize & Self::MARK_BITMASK)) as *mut _;
+    }
+}
+
+impl<T: Default> Default for GcBox<T> {
+    fn default() -> Self {
+        Self {
+            next: std::ptr::null_mut(),
+            value: T::default(),
+        }
+    }
+}
+
+impl<T> Deref for GcBox<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for GcBox<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}

--- a/som-gc/src/gc_box.rs
+++ b/som-gc/src/gc_box.rs
@@ -1,61 +1,50 @@
 use std::ops::{Deref, DerefMut};
+use std::cell::Cell;
+use std::ptr::NonNull;
+
+use crate::Trace;
 
 /// Represents a value, as it is stored within the GC.
-pub(crate) struct GcBox<T> {
+pub(crate) struct GcBox<T: ?Sized> {
     /// Pointer to next value in the GC chain.  
-    ///
-    /// We also use the unused bits of this pointer to store the `marked` bitflag.  
-    /// Therefore, it not suitable for it to be dereferenced as-is, it must first
-    /// be cleared of these flags before any accesses are performed.  
-    /// This is also why this is not represented as a `Option<NonNull<GcBox<T>>>`
-    pub(crate) next: *mut GcBox<T>,
+    pub(crate) marked: Cell<bool>,
+    pub(crate) next: Option<NonNull<GcBox<dyn Trace + 'static>>>,
     pub(crate) value: T,
 }
 
 impl<T> GcBox<T> {
-    /// Bitflag for whether the current GC object is marked (still referenced).
-    pub const MARK_BITMASK: usize = 0b0000_0001;
-    /// Bitmask for the bits reserved for GC flags within the `next` pointer in `GcBox`.
-    pub const FLAGS_BITMASK: usize = 0b0000_0011;
-
     /// Creates a singleton `GcBox` value (which isn't part of any chain yet).
     pub fn new(value: T) -> Self {
         Self {
-            next: std::ptr::null_mut(),
+            marked: Cell::new(false),
+            next: None,
             value,
         }
     }
+}
 
+impl<T: ?Sized> GcBox<T> {
     /// Clears the `mark` bit for this GC object.
     pub fn clear_mark(&mut self) {
-        self.next = (self.next as usize & !Self::MARK_BITMASK) as *mut _;
+        self.marked.set(false);
     }
 
     /// Sets the `mark` bit for this GC object.
     pub fn mark(&mut self) {
-        self.next = (self.next as usize | Self::MARK_BITMASK) as *mut _;
+        self.marked.set(true);
     }
 
     /// Returns whether the `mark` bit is set for this GC object.
     pub fn is_marked(&self) -> bool {
-        self.next as usize & Self::MARK_BITMASK == 1
-    }
-
-    /// Returns the pointer to the next GC object in the chain.
-    pub fn next(&self) -> *mut GcBox<T> {
-        (self.next as usize & !Self::FLAGS_BITMASK) as *mut _
-    }
-
-    /// Sets the pointer to the next GC object in the chain, and preserving all the current bitflags.
-    pub fn set_next(&mut self, next: *mut GcBox<T>) {
-        self.next = (next as usize | (self.next as usize & Self::MARK_BITMASK)) as *mut _;
+        self.marked.get()
     }
 }
 
 impl<T: Default> Default for GcBox<T> {
     fn default() -> Self {
         Self {
-            next: std::ptr::null_mut(),
+            marked: Cell::new(false),
+            next: None,
             value: T::default(),
         }
     }

--- a/som-gc/src/heap.rs
+++ b/som-gc/src/heap.rs
@@ -1,5 +1,4 @@
 use std::cell::Cell;
-use std::marker::PhantomData;
 use std::ptr::NonNull;
 use std::time::{Duration, Instant};
 
@@ -89,7 +88,6 @@ impl GcHeap {
         self.stats.bytes_allocated += std::mem::size_of::<GcBox<T>>();
         Gc {
             ptr: Cell::new(ptr),
-            marker: PhantomData,
         }
     }
 

--- a/som-gc/src/heap.rs
+++ b/som-gc/src/heap.rs
@@ -94,6 +94,7 @@ impl GcHeap {
     }
 
     /// Clears the `mark` bits on every GC object.
+    #[allow(unused)]
     fn clear_marks(&mut self) {
         let mut head = self.head;
         while let Some(mut cur) = head {
@@ -123,6 +124,7 @@ impl GcHeap {
                 self.stats.bytes_allocated -= std::mem::size_of_val::<GcBox<_>>(&*value);
                 drop(value);
             } else {
+                cur_ref.marked.set(false);
                 prev = head;
             }
             head = next;
@@ -133,7 +135,6 @@ impl GcHeap {
     pub fn collect_garbage(&mut self, mut mark_fn: impl FnMut()) {
         let start = Instant::now();
         let allocated_start = self.stats.bytes_allocated;
-        self.clear_marks();
         mark_fn();
         self.sweep();
         self.stats.bytes_swept += allocated_start - self.stats.bytes_allocated;

--- a/som-gc/src/heap.rs
+++ b/som-gc/src/heap.rs
@@ -1,15 +1,39 @@
 use std::cell::Cell;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
+use std::time::{Duration, Instant};
 
 use crate::gc_box::GcBox;
 
 use crate::gc::Gc;
 use crate::trace::Trace;
 
+pub struct GcStats {
+    pub collections_performed: usize,
+    pub bytes_allocated: usize,
+    pub bytes_swept: usize,
+    pub total_time_spent: Duration,
+}
+
+pub struct GcParams {
+    pub threshold: usize,
+    pub used_space_ratio: f64,
+}
+
 /// The GC heap itself, which is the storage for all GC-ed objects.
 pub struct GcHeap {
+    stats: GcStats,
+    params: GcParams,
     head: Option<NonNull<GcBox<dyn Trace + 'static>>>,
+}
+
+impl Default for GcParams {
+    fn default() -> Self {
+        Self {
+            threshold: 10_000_000,
+            used_space_ratio: 0.7,
+        }
+    }
 }
 
 impl Drop for GcHeap {
@@ -25,11 +49,33 @@ impl Drop for GcHeap {
 }
 
 impl GcHeap {
-    /// Creates a new empty GC heap.
+    /// Creates a new empty GC heap, with the default parameters.
     pub fn new() -> Self {
+        Self::with_params(GcParams::default())
+    }
+
+    /// Creates a new empty GC heap, with the specified parameters.
+    pub fn with_params(params: GcParams) -> Self {
         Self {
+            params,
+            stats: GcStats {
+                collections_performed: 0,
+                bytes_allocated: 0,
+                bytes_swept: 0,
+                total_time_spent: Duration::ZERO,
+            },
             head: None,
         }
+    }
+
+    /// Returns a reference to the GC's stats.
+    pub fn stats(&self) -> &GcStats {
+        &self.stats
+    }
+
+    /// Returns a reference to the GC's parameters.
+    pub fn params(&self) -> &GcParams {
+        &self.params
     }
 
     /// Allocates an object on the GC heap, returning its handle.
@@ -39,6 +85,7 @@ impl GcHeap {
         allocated.next = self.head;
         let ptr = unsafe { NonNull::new_unchecked(Box::into_raw(allocated)) };
         self.head = Some(ptr as NonNull<GcBox<dyn Trace + 'static>>);
+        self.stats.bytes_allocated += std::mem::size_of::<GcBox<T>>();
         Gc {
             // SAFETY: `self.head` is guaranteed to be properly aligned and non-null by `Box::into_raw`.
             ptr: Cell::new(ptr),
@@ -72,7 +119,9 @@ impl GcHeap {
                 }
                 // TODO: introduce a `Finalize`-like mechanism.
                 // TODO: maybe perform the drops in a separate thread.
-                drop(unsafe { Box::from_raw(cur.as_ptr()) });
+                let value = unsafe { Box::from_raw(cur.as_ptr()) };
+                self.stats.bytes_allocated -= std::mem::size_of_val::<GcBox<_>>(&*value);
+                drop(value);
             } else {
                 prev = head;
             }
@@ -82,8 +131,27 @@ impl GcHeap {
 
     /// Performs garbage collection (mark-and-sweep) on the GC heap.
     pub fn collect_garbage(&mut self, mut mark_fn: impl FnMut()) {
+        let start = Instant::now();
+        let allocated_start = self.stats.bytes_allocated;
         self.clear_marks();
         mark_fn();
         self.sweep();
+        self.stats.bytes_swept += allocated_start - self.stats.bytes_allocated;
+        self.stats.total_time_spent += start.elapsed();
+        self.stats.collections_performed += 1;
+    }
+
+    /// Performs garbage collection (mark-and-sweep) on the GC heap, only if necessary.
+    pub fn maybe_collect_garbage(&mut self, mark_fn: impl FnMut()) {
+        if self.stats.bytes_allocated > self.params.threshold {
+            self.collect_garbage(mark_fn);
+
+            if self.stats.bytes_allocated as f64
+                > self.params.threshold as f64 * self.params.used_space_ratio
+            {
+                self.params.threshold =
+                    (self.stats.bytes_allocated as f64 / self.params.used_space_ratio) as usize
+            }
+        }
     }
 }

--- a/som-gc/src/heap.rs
+++ b/som-gc/src/heap.rs
@@ -83,11 +83,11 @@ impl GcHeap {
         // TODO: trigger `collect_garbage`
         let mut allocated = Box::new(GcBox::new(value));
         allocated.next = self.head;
+        // SAFETY: `self.head` is guaranteed to be properly aligned and non-null by `Box::into_raw`.
         let ptr = unsafe { NonNull::new_unchecked(Box::into_raw(allocated)) };
         self.head = Some(ptr as NonNull<GcBox<dyn Trace + 'static>>);
         self.stats.bytes_allocated += std::mem::size_of::<GcBox<T>>();
         Gc {
-            // SAFETY: `self.head` is guaranteed to be properly aligned and non-null by `Box::into_raw`.
             ptr: Cell::new(ptr),
             marker: PhantomData,
         }

--- a/som-gc/src/heap.rs
+++ b/som-gc/src/heap.rs
@@ -1,0 +1,98 @@
+use std::cell::Cell;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+use crate::gc_box::GcBox;
+
+use crate::gc::Gc;
+use crate::trace::Trace;
+
+/// The GC heap itself, which is the storage for all GC-ed objects.
+pub struct GcHeap<T>
+where
+    T: Trace + 'static,
+{
+    head: *mut GcBox<T>,
+}
+
+impl<T> Drop for GcHeap<T>
+where
+    T: Trace + 'static,
+{
+    // We properly drop all objects in the heap.
+    fn drop(&mut self) {
+        let mut head: *mut GcBox<T> = self.head;
+        while !head.is_null() {
+            // SAFETY: we don't access that reference again after we drop it.
+            let next = unsafe { &*head }.next();
+            drop(unsafe { Box::from_raw(head) });
+            head = next;
+        }
+    }
+}
+
+impl<T> GcHeap<T>
+where
+    T: Trace + 'static,
+{
+    /// Creates a new empty GC heap.
+    pub fn new() -> Self {
+        Self {
+            head: std::ptr::null_mut(),
+        }
+    }
+
+    /// Allocates an object on the GC heap, returning its handle.
+    pub fn allocate(&mut self, value: T) -> Gc<T> {
+        // TODO: trigger `collect_garbage`
+        let mut allocated = Box::new(GcBox::new(value));
+        allocated.set_next(self.head);
+        self.head = Box::into_raw(allocated);
+        Gc {
+            // SAFETY: `self.head` is guaranteed to be properly aligned and non-null by `Box::into_raw`.
+            ptr: Cell::new(unsafe { NonNull::new_unchecked(self.head) }),
+            marker: PhantomData,
+        }
+    }
+
+    /// Clears the `mark` bits on every GC object.
+    fn clear_marks(&mut self) {
+        let mut head = self.head;
+        while !head.is_null() {
+            let head_ref = unsafe { &mut *head };
+            head_ref.clear_mark();
+            head = head_ref.next();
+        }
+    }
+
+    /// Performs a sweep on the GC heap (drops all unmarked objects).
+    fn sweep(&mut self) {
+        let mut head: *mut GcBox<T> = self.head;
+        let mut prev: *mut GcBox<T> = std::ptr::null_mut();
+        while !head.is_null() {
+            // SAFETY: we don't access that reference again after we drop it.
+            let head_ref = unsafe { &*head };
+            let next = head_ref.next();
+            if !head_ref.is_marked() {
+                if !prev.is_null() {
+                    unsafe { &mut *prev }.set_next(next);
+                } else {
+                    self.head = next;
+                }
+                // TODO: introduce a `Finalize`-like mechanism.
+                // TODO: maybe perform the drops in a separate thread.
+                drop(unsafe { Box::from_raw(head) });
+            } else {
+                prev = head;
+            }
+            head = next;
+        }
+    }
+
+    /// Performs garbage collection (mark-and-sweep) on the GC heap.
+    pub fn collect_garbage(&mut self, mut mark_fn: impl FnMut()) {
+        self.clear_marks();
+        mark_fn();
+        self.sweep();
+    }
+}

--- a/som-gc/src/lib.rs
+++ b/som-gc/src/lib.rs
@@ -1,0 +1,8 @@
+mod gc;
+mod gc_box;
+mod heap;
+mod trace;
+
+pub use crate::gc::Gc;
+pub use crate::heap::GcHeap;
+pub use crate::trace::Trace;

--- a/som-gc/src/lib.rs
+++ b/som-gc/src/lib.rs
@@ -4,5 +4,5 @@ mod heap;
 mod trace;
 
 pub use crate::gc::Gc;
-pub use crate::heap::GcHeap;
+pub use crate::heap::{GcHeap, GcParams};
 pub use crate::trace::Trace;

--- a/som-gc/src/trace.rs
+++ b/som-gc/src/trace.rs
@@ -1,0 +1,155 @@
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
+use std::num::{
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
+    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::atomic::{
+    AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16, AtomicU32,
+    AtomicU64, AtomicU8, AtomicUsize,
+};
+
+pub trait Trace {
+    fn trace(&self);
+}
+
+macro_rules! trivial_trace {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl $crate::trace::Trace for $ty {
+                fn trace(&self) {}
+            }
+        )*
+    };
+}
+
+trivial_trace![
+    (),
+    bool,
+    isize,
+    usize,
+    i8,
+    u8,
+    i16,
+    u16,
+    i32,
+    u32,
+    i64,
+    u64,
+    i128,
+    u128,
+    f32,
+    f64,
+    char,
+    String,
+    Box<str>,
+    Rc<str>,
+    Path,
+    PathBuf,
+    NonZeroIsize,
+    NonZeroUsize,
+    NonZeroI8,
+    NonZeroU8,
+    NonZeroI16,
+    NonZeroU16,
+    NonZeroI32,
+    NonZeroU32,
+    NonZeroI64,
+    NonZeroU64,
+    NonZeroI128,
+    NonZeroU128,
+    AtomicBool,
+    AtomicIsize,
+    AtomicUsize,
+    AtomicI8,
+    AtomicU8,
+    AtomicI16,
+    AtomicU16,
+    AtomicI32,
+    AtomicU32,
+    AtomicI64,
+    AtomicU64,
+];
+
+macro_rules! tuple_trace {
+    () => {};
+    ($head:ident $($X:ident)*) => {
+        tuple_trace!($($X)*);
+        tuple_trace!(~ $head $($X)*);
+    };
+    (~ $($X:ident)*) => {
+        #[allow(non_snake_case)]
+        impl<$($X: $crate::trace::Trace),*> Trace for ($($X,)*) {
+            fn trace(&self) {
+                let ($($X,)*) = self;
+                $($X.trace();)*
+            }
+        }
+    };
+}
+
+tuple_trace!(A_ B_ C_ D_ E_ F_ G_ H_ I_ J_ K_ L_ M_ N_ O_ P_ Q_ S_ T_ U_ V_ W_ X_ Y_ Z_);
+
+macro_rules! iter_1_trace {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl<T: $crate::trace::Trace> $crate::trace::Trace for $ty {
+                fn trace(&self) {
+                    for it in self.into_iter() {
+                        it.trace();
+                    }
+                }
+            }
+        )*
+    };
+}
+
+iter_1_trace!(
+    Vec<T>,
+    VecDeque<T>,
+    LinkedList<T>,
+    HashSet<T>,
+    BTreeSet<T>,
+    BinaryHeap<T>
+);
+
+macro_rules! iter_2_trace {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl<K: $crate::trace::Trace, V: $crate::trace::Trace> $crate::trace::Trace for $ty {
+                fn trace(&self) {
+                    for (k, v) in self.into_iter() {
+                        k.trace();
+                        v.trace();
+                    }
+                }
+            }
+        )*
+    };
+}
+
+iter_2_trace!(HashMap<K, V>, BTreeMap<K, V>);
+
+impl<T: Trace> Trace for &[T] {
+    fn trace(&self) {
+        for it in self.into_iter() {
+            it.trace();
+        }
+    }
+}
+
+impl<T: Trace, const N: usize> Trace for [T; N] {
+    fn trace(&self) {
+        for it in self.into_iter() {
+            it.trace();
+        }
+    }
+}
+
+impl<T: Trace> Trace for RefCell<T> {
+    fn trace(&self) {
+        self.borrow().trace();
+    }
+}

--- a/som-gc/src/trace.rs
+++ b/som-gc/src/trace.rs
@@ -19,6 +19,7 @@ macro_rules! trivial_trace {
     ($($ty:ty),* $(,)?) => {
         $(
             impl $crate::trace::Trace for $ty {
+                #[inline]
                 fn trace(&self) {}
             }
         )*
@@ -82,6 +83,7 @@ macro_rules! tuple_trace {
     (~ $($X:ident)*) => {
         #[allow(non_snake_case)]
         impl<$($X: $crate::trace::Trace),*> Trace for ($($X,)*) {
+            #[inline]
             fn trace(&self) {
                 let ($($X,)*) = self;
                 $($X.trace();)*
@@ -96,6 +98,7 @@ macro_rules! iter_1_trace {
     ($($ty:ty),* $(,)?) => {
         $(
             impl<T: $crate::trace::Trace> $crate::trace::Trace for $ty {
+                #[inline]
                 fn trace(&self) {
                     for it in self.into_iter() {
                         it.trace();
@@ -119,6 +122,7 @@ macro_rules! iter_2_trace {
     ($($ty:ty),* $(,)?) => {
         $(
             impl<K: $crate::trace::Trace, V: $crate::trace::Trace> $crate::trace::Trace for $ty {
+                #[inline]
                 fn trace(&self) {
                     for (k, v) in self.into_iter() {
                         k.trace();
@@ -133,6 +137,7 @@ macro_rules! iter_2_trace {
 iter_2_trace!(HashMap<K, V>, BTreeMap<K, V>);
 
 impl<T: Trace> Trace for &[T] {
+    #[inline]
     fn trace(&self) {
         for it in self.into_iter() {
             it.trace();
@@ -141,6 +146,7 @@ impl<T: Trace> Trace for &[T] {
 }
 
 impl<T: Trace, const N: usize> Trace for [T; N] {
+    #[inline]
     fn trace(&self) {
         for it in self.into_iter() {
             it.trace();
@@ -149,7 +155,27 @@ impl<T: Trace, const N: usize> Trace for [T; N] {
 }
 
 impl<T: Trace> Trace for RefCell<T> {
+    #[inline]
     fn trace(&self) {
         self.borrow().trace();
     }
+}
+
+impl<T: Trace> Trace for Option<T> {
+    #[inline]
+    fn trace(&self) {
+        if let Some(value) = self {
+            value.trace();
+        }
+    }
+}
+
+impl<T: Trace> Trace for *const T {
+    #[inline]
+    fn trace(&self) {}
+}
+
+impl<T: Trace> Trace for *mut T {
+    #[inline]
+    fn trace(&self) {}
 }

--- a/som-gc/tests/cycle.rs
+++ b/som-gc/tests/cycle.rs
@@ -1,0 +1,44 @@
+use std::cell::RefCell;
+
+use som_gc::{Gc, GcHeap, Trace};
+
+struct Node {
+    id: usize,
+    edge: Option<Gc<RefCell<Node>>>,
+}
+
+impl Trace for Node {
+    fn trace(&self) {
+        if let Some(edge) = self.edge.as_ref() {
+            edge.trace();
+        }
+    }
+}
+
+impl Drop for Node {
+    fn drop(&mut self) {
+        println!("dropped node {}", self.id);
+    }
+}
+
+fn main() {
+    let mut heap = GcHeap::new();
+
+    let a = heap.allocate(RefCell::new(Node { id: 1, edge: None }));
+    let b = heap.allocate(RefCell::new(Node { id: 2, edge: None }));
+
+    a.borrow_mut().edge = Some(b.clone());
+    b.borrow_mut().edge = Some(a.clone());
+
+    drop(b);
+
+    println!("collection 1: START");
+    heap.collect_garbage(|| a.trace());
+    println!("collection 1: END");
+
+    drop(a);
+
+    println!("collection 2: START");
+    heap.collect_garbage(|| {});
+    println!("collection 2: END");
+}

--- a/som-gc/tests/cycle.rs
+++ b/som-gc/tests/cycle.rs
@@ -21,7 +21,8 @@ impl Drop for Node {
     }
 }
 
-fn main() {
+#[test]
+fn cycle_test() {
     let mut heap = GcHeap::new();
 
     let a = heap.allocate(RefCell::new(Node { id: 1, edge: None }));

--- a/som-gc/tests/simple.rs
+++ b/som-gc/tests/simple.rs
@@ -1,0 +1,47 @@
+use som_gc::{GcHeap, Trace};
+
+struct Test {
+    value: usize,
+}
+
+impl Test {
+    pub fn new(value: usize) -> Self {
+        Self { value }
+    }
+
+    pub fn say_hello(&self) {
+        println!("hello from {}", self.value);
+    }
+}
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        println!("dropped value {}", self.value);
+    }
+}
+
+impl Trace for Test {
+    fn trace(&self) {}
+}
+
+fn main() {
+    let mut heap = GcHeap::new();
+
+    let mut stack = Vec::new();
+
+    stack.push(heap.allocate(Test::new(3)));
+    stack.push(heap.allocate(Test::new(4)));
+    stack.push(heap.allocate(Test::new(5)));
+
+    stack.iter().for_each(|it| it.say_hello());
+
+    println!("collection 1: START");
+    heap.collect_garbage(|| stack.trace());
+    println!("collection 1: END");
+
+    stack.remove(1);
+
+    println!("collection 2: START");
+    heap.collect_garbage(|| stack.trace());
+    println!("collection 2: END");
+}

--- a/som-gc/tests/simple.rs
+++ b/som-gc/tests/simple.rs
@@ -24,7 +24,8 @@ impl Trace for Test {
     fn trace(&self) {}
 }
 
-fn main() {
+#[test]
+fn simple_test() {
     let mut heap = GcHeap::new();
 
     let mut stack = Vec::new();

--- a/som-interpreter-bc/Cargo.toml
+++ b/som-interpreter-bc/Cargo.toml
@@ -13,6 +13,7 @@ som-core = { path = "../som-core", version = "0.1.0" }
 som-lexer = { path = "../som-lexer", version = "0.1.0" }
 som-parser = { package = "som-parser-symbols", path = "../som-parser-symbols", version = "0.1.0" }
 # som-parser = { package = "som-parser-text", path = "../som-parser-text", version = "0.1.0" }
+som-gc = { path = "../som-gc", version = "0.1.0" }
 
 # CLI interface
 clap = { version = "3.0", features = ["derive"] }

--- a/som-interpreter-bc/README.md
+++ b/som-interpreter-bc/README.md
@@ -5,4 +5,4 @@ This is the interpreter for the Simple Object Machine.
 
 It is bytecode-based, in that it works by compiling nodes from the Abstract Syntax Tree from **`som-core`** into stack-based bytecode instructions and then executing them.  
 
-Resources are managed and tracked through reference-counting (using Rust's **`Rc`**/**`Weak`** types).  
+Resources are managed using a mark-and-sweep garbage collector (from the `som-gc` library).  

--- a/som-interpreter-bc/src/block.rs
+++ b/som-interpreter-bc/src/block.rs
@@ -1,8 +1,8 @@
 use std::cell::RefCell;
 use std::fmt;
-use std::rc::Rc;
 
 use som_core::bytecode::Bytecode;
+use som_gc::{Gc, Trace};
 
 use crate::class::Class;
 use crate::compiler::Literal;
@@ -18,7 +18,7 @@ pub struct BlockInfo {
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
     pub nb_params: usize,
-    pub inline_cache: RefCell<Vec<Option<(*const Class, Rc<Method>)>>>,
+    pub inline_cache: RefCell<Vec<Option<(*const Class, Gc<Method>)>>>,
 }
 
 /// Represents an executable block.
@@ -26,7 +26,24 @@ pub struct BlockInfo {
 pub struct Block {
     /// Reference to the captured stack frame.
     pub frame: Option<SOMRef<Frame>>,
-    pub blk_info: Rc<BlockInfo>,
+    pub blk_info: Gc<BlockInfo>,
+}
+
+impl Trace for BlockInfo {
+    #[inline]
+    fn trace(&self) {
+        self.locals.trace();
+        self.literals.trace();
+        self.inline_cache.trace();
+    }
+}
+
+impl Trace for Block {
+    #[inline]
+    fn trace(&self) {
+        self.frame.trace();
+        self.blk_info.trace();
+    }
 }
 
 impl Block {

--- a/som-interpreter-bc/src/block.rs
+++ b/som-interpreter-bc/src/block.rs
@@ -32,7 +32,6 @@ pub struct Block {
 impl Trace for BlockInfo {
     #[inline]
     fn trace(&self) {
-        self.locals.trace();
         self.literals.trace();
         self.inline_cache.trace();
     }

--- a/som-interpreter-bc/src/block.rs
+++ b/som-interpreter-bc/src/block.rs
@@ -18,7 +18,7 @@ pub struct BlockInfo {
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
     pub nb_params: usize,
-    pub inline_cache: RefCell<Vec<Option<(*const Class, Gc<Method>)>>>,
+    pub inline_cache: RefCell<Vec<Option<(*const RefCell<Class>, Gc<Method>)>>>,
 }
 
 /// Represents an executable block.

--- a/som-interpreter-bc/src/class.rs
+++ b/som-interpreter-bc/src/class.rs
@@ -1,21 +1,13 @@
 use std::fmt;
-use std::rc::Rc;
 
 use indexmap::IndexMap;
+
+use som_gc::{Gc, Trace};
 
 use crate::interner::Interned;
 use crate::method::Method;
 use crate::value::Value;
-use crate::{SOMRef, SOMWeakRef};
-
-/// A reference that may be either weak or owned/strong.
-#[derive(Debug, Clone)]
-pub enum MaybeWeak<A> {
-    /// An owned reference.
-    Strong(SOMRef<A>),
-    /// A weak reference.
-    Weak(SOMWeakRef<A>),
-}
+use crate::SOMRef;
 
 /// Represents a loaded class.
 #[derive(Clone)]
@@ -23,16 +15,29 @@ pub struct Class {
     /// The class' name.
     pub name: String,
     /// The class of this class.
-    pub class: MaybeWeak<Class>,
+    pub class: Option<SOMRef<Class>>,
     /// The superclass of this class.
-    // TODO: Should probably be `Option<SOMRef<Class>>`.
-    pub super_class: SOMWeakRef<Class>,
+    pub super_class: Option<SOMRef<Class>>,
     /// The class' locals.
     pub locals: IndexMap<Interned, Value>,
     /// The class' methods/invokables.
-    pub methods: IndexMap<Interned, Rc<Method>>,
+    pub methods: IndexMap<Interned, Gc<Method>>,
     /// Is this class a static one ?
     pub is_static: bool,
+}
+
+impl Trace for Class {
+    #[inline]
+    fn trace(&self) {
+        self.class.trace();
+        self.super_class.trace();
+        for it in self.locals.values() {
+            it.trace();
+        }
+        for it in self.methods.values() {
+            it.trace();
+        }
+    }
 }
 
 impl Class {
@@ -43,51 +48,40 @@ impl Class {
 
     /// Get the class of this class.
     pub fn class(&self) -> SOMRef<Self> {
-        match self.class {
-            MaybeWeak::Weak(ref weak) => weak.upgrade().unwrap_or_else(|| {
-                panic!("superclass dropped, cannot upgrade ref ({})", self.name())
-            }),
-            MaybeWeak::Strong(ref owned) => owned.clone(),
-        }
+        self.class.clone().unwrap()
     }
 
-    /// Set the class of this class (as a weak reference).
-    pub fn set_class(&mut self, class: &SOMRef<Self>) {
-        self.class = MaybeWeak::Weak(Rc::downgrade(class));
-    }
-
-    /// Set the class of this class (as a strong reference).
-    pub fn set_class_owned(&mut self, class: &SOMRef<Self>) {
-        self.class = MaybeWeak::Strong(class.clone());
+    /// Set the class of this class.
+    pub fn set_class(&mut self, class: SOMRef<Self>) {
+        self.class = Some(class);
     }
 
     /// Get the superclass of this class.
     pub fn super_class(&self) -> Option<SOMRef<Self>> {
-        self.super_class.upgrade()
+        self.super_class.clone()
     }
 
-    /// Set the superclass of this class (as a weak reference).
-    pub fn set_super_class(&mut self, class: &SOMRef<Self>) {
-        self.super_class = Rc::downgrade(class);
+    /// Set the superclass of this class.
+    pub fn set_super_class(&mut self, class: SOMRef<Self>) {
+        self.super_class = Some(class);
     }
 
     /// Search for a given method within this class.
-    pub fn lookup_method(&self, signature: Interned) -> Option<Rc<Method>> {
-        self.methods.get(&signature).cloned().or_else(|| {
-            self.super_class
-                .upgrade()?
-                .borrow()
-                .lookup_method(signature)
-        })
+    pub fn lookup_method(&self, signature: Interned) -> Option<Gc<Method>> {
+        if let Some(method) = self.methods.get(&signature).cloned() {
+            return Some(method);
+        }
+
+        self.super_class.as_ref()?.borrow().lookup_method(signature)
     }
 
     /// Search for a local binding.
     pub fn lookup_local(&self, idx: usize) -> Option<Value> {
-        self.locals.values().nth(idx).cloned().or_else(|| {
-            let super_class = self.super_class()?;
-            let local = super_class.borrow_mut().lookup_local(idx)?;
-            Some(local)
-        })
+        if let Some(local) = self.locals.values().nth(idx).cloned() {
+            return Some(local);
+        }
+
+        self.super_class.as_ref()?.borrow_mut().lookup_local(idx)
     }
 
     /// Assign a value to a local binding.
@@ -96,9 +90,11 @@ impl Class {
             *local = value;
             return Some(());
         }
-        let super_class = self.super_class()?;
-        super_class.borrow_mut().assign_local(idx, value)?;
-        Some(())
+
+        self.super_class
+            .as_ref()?
+            .borrow_mut()
+            .assign_local(idx, value)
     }
 }
 

--- a/som-interpreter-bc/src/compiler.rs
+++ b/som-interpreter-bc/src/compiler.rs
@@ -3,16 +3,16 @@
 //!
 use std::cell::RefCell;
 use std::hash::{Hash, Hasher};
-use std::rc::{Rc, Weak};
 
 use indexmap::{IndexMap, IndexSet};
 use num_bigint::BigInt;
 
 use som_core::ast;
 use som_core::bytecode::Bytecode;
+use som_gc::{Gc, GcHeap, Trace};
 
 use crate::block::{Block, BlockInfo};
-use crate::class::{Class, MaybeWeak};
+use crate::class::Class;
 use crate::interner::{Interned, Interner};
 use crate::method::{Method, MethodEnv, MethodKind};
 use crate::primitives;
@@ -22,12 +22,31 @@ use crate::SOMRef;
 #[derive(Debug, Clone)]
 pub enum Literal {
     Symbol(Interned),
-    String(Rc<String>),
+    String(Gc<String>),
     Double(f64),
     Integer(i64),
     BigInteger(BigInt),
     Array(Vec<u8>),
-    Block(Rc<Block>),
+    Block(Gc<Block>),
+}
+
+impl Trace for Literal {
+    #[inline]
+    fn trace(&self) {
+        match self {
+            Literal::Symbol(_) => {}
+            Literal::String(string) => {
+                string.trace();
+            }
+            Literal::Double(_) => {}
+            Literal::Integer(_) => {}
+            Literal::BigInteger(_) => {}
+            Literal::Array(_) => {}
+            Literal::Block(block) => {
+                block.trace();
+            }
+        }
+    }
 }
 
 impl PartialEq for Literal {
@@ -39,7 +58,7 @@ impl PartialEq for Literal {
             (Literal::Integer(val1), Literal::Integer(val2)) => val1.eq(val2),
             (Literal::BigInteger(val1), Literal::BigInteger(val2)) => val1.eq(val2),
             (Literal::Array(val1), Literal::Array(val2)) => val1.eq(val2),
-            (Literal::Block(val1), Literal::Block(val2)) => Rc::ptr_eq(val1, val2),
+            (Literal::Block(val1), Literal::Block(val2)) => Gc::ptr_eq(val1, val2),
             _ => false,
         }
     }
@@ -92,6 +111,7 @@ trait GenCtxt {
     fn find_var(&mut self, name: &str) -> Option<FoundVar>;
     fn intern_symbol(&mut self, name: &str) -> Interned;
     fn class_name(&self) -> &str;
+    fn heap(&mut self) -> &mut GcHeap;
 }
 
 trait InnerGenCtxt: GenCtxt {
@@ -135,6 +155,10 @@ impl GenCtxt for BlockGenCtxt<'_> {
 
     fn class_name(&self) -> &str {
         self.outer.class_name()
+    }
+
+    fn heap(&mut self) -> &mut GcHeap {
+        self.outer.heap()
     }
 }
 
@@ -218,6 +242,10 @@ impl GenCtxt for MethodGenCtxt<'_> {
 
     fn class_name(&self) -> &str {
         self.inner.class_name()
+    }
+
+    fn heap(&mut self) -> &mut GcHeap {
+        self.inner.heap()
     }
 }
 
@@ -359,7 +387,9 @@ impl MethodCodegen for ast::Expression {
                         ast::Literal::Symbol(val) => {
                             Literal::Symbol(ctxt.intern_symbol(val.as_str()))
                         }
-                        ast::Literal::String(val) => Literal::String(Rc::new(val.clone())),
+                        ast::Literal::String(val) => {
+                            Literal::String(ctxt.heap().allocate(val.clone()))
+                        }
                         ast::Literal::Double(val) => Literal::Double(*val),
                         ast::Literal::Integer(val) => Literal::Integer(*val),
                         ast::Literal::BigInteger(val) => Literal::BigInteger(val.parse().unwrap()),
@@ -396,7 +426,7 @@ impl MethodCodegen for ast::Expression {
             }
             ast::Expression::Block(val) => {
                 let block = compile_block(ctxt.as_gen_ctxt(), val)?;
-                let block = Rc::new(block);
+                let block = ctxt.heap().allocate(block);
                 let block = Literal::Block(block);
                 let idx = ctxt.push_literal(block);
                 ctxt.push_instr(Bytecode::PushBlock(idx as u8));
@@ -409,8 +439,9 @@ impl MethodCodegen for ast::Expression {
 struct ClassGenCtxt<'a> {
     pub name: String,
     pub fields: IndexSet<Interned>,
-    pub methods: IndexMap<Interned, Rc<Method>>,
+    pub methods: IndexMap<Interned, Gc<Method>>,
     pub interner: &'a mut Interner,
+    pub heap: &'a mut GcHeap,
 }
 
 impl GenCtxt for ClassGenCtxt<'_> {
@@ -428,9 +459,17 @@ impl GenCtxt for ClassGenCtxt<'_> {
     fn class_name(&self) -> &str {
         self.name.as_str()
     }
+
+    fn heap(&mut self) -> &mut GcHeap {
+        self.heap
+    }
 }
 
-fn compile_method(outer: &mut dyn GenCtxt, defn: &ast::MethodDef) -> Option<Method> {
+fn compile_method(
+    outer: &mut dyn GenCtxt,
+    holder: &SOMRef<Class>,
+    defn: &ast::MethodDef,
+) -> Option<Method> {
     // println!("(method) compiling '{}' ...", defn.signature);
 
     let mut ctxt = MethodGenCtxt {
@@ -499,7 +538,7 @@ fn compile_method(outer: &mut dyn GenCtxt, defn: &ast::MethodDef) -> Option<Meth
                 })
             }
         },
-        holder: Weak::new(),
+        holder: holder.clone(),
         signature: ctxt.signature,
     };
 
@@ -529,6 +568,9 @@ fn compile_block(outer: &mut dyn GenCtxt, defn: &ast::Block) -> Option<Block> {
         ctxt.push_instr(Bytecode::ReturnLocal);
     }
 
+    let body_len = ctxt.body.as_ref().map_or(0, |body| body.len());
+    let inline_cache = RefCell::new(vec![None; body_len]);
+
     let frame = None;
     let locals = {
         let locals = std::mem::take(&mut ctxt.locals);
@@ -540,11 +582,10 @@ fn compile_block(outer: &mut dyn GenCtxt, defn: &ast::Block) -> Option<Block> {
     let literals = ctxt.literals.into_iter().collect();
     let body = ctxt.body.unwrap_or_default();
     let nb_params = ctxt.args.len();
-    let inline_cache = RefCell::new(vec![None; body.len()]);
 
     let block = Block {
         frame,
-        blk_info: Rc::new(BlockInfo {
+        blk_info: ctxt.heap().allocate(BlockInfo {
             locals,
             literals,
             body,
@@ -559,6 +600,7 @@ fn compile_block(outer: &mut dyn GenCtxt, defn: &ast::Block) -> Option<Block> {
 }
 
 pub fn compile_class(
+    heap: &mut GcHeap,
     interner: &mut Interner,
     defn: &ast::ClassDef,
     super_class: Option<&SOMRef<Class>>,
@@ -591,12 +633,13 @@ pub fn compile_class(
         fields: locals,
         methods: IndexMap::new(),
         interner,
+        heap,
     };
 
-    let static_class = Rc::new(RefCell::new(Class {
+    let static_class = static_class_ctxt.heap.allocate(RefCell::new(Class {
         name: static_class_ctxt.name.clone(),
-        class: MaybeWeak::Weak(Weak::new()),
-        super_class: Weak::new(),
+        class: None,
+        super_class: None,
         locals: IndexMap::new(),
         methods: IndexMap::new(),
         is_static: true,
@@ -604,9 +647,9 @@ pub fn compile_class(
 
     for method in &defn.static_methods {
         let signature = static_class_ctxt.interner.intern(method.signature.as_str());
-        let mut method = compile_method(&mut static_class_ctxt, method)?;
-        method.holder = Rc::downgrade(&static_class);
-        static_class_ctxt.methods.insert(signature, Rc::new(method));
+        let method = compile_method(&mut static_class_ctxt, &static_class, method)?;
+        let method = static_class_ctxt.heap.allocate(method);
+        static_class_ctxt.methods.insert(signature, method);
     }
 
     if let Some(primitives) = primitives::get_class_primitives(&defn.name) {
@@ -622,10 +665,11 @@ pub fn compile_class(
             let method = Method {
                 signature: signature.to_string(),
                 kind: MethodKind::Primitive(primitive),
-                holder: Rc::downgrade(&static_class),
+                holder: static_class.clone(),
             };
             let signature = static_class_ctxt.interner.intern(signature);
-            static_class_ctxt.methods.insert(signature, Rc::new(method));
+            let method = static_class_ctxt.heap.allocate(method);
+            static_class_ctxt.methods.insert(signature, method);
         }
     }
 
@@ -670,12 +714,13 @@ pub fn compile_class(
         fields: locals,
         methods: IndexMap::new(),
         interner,
+        heap,
     };
 
-    let instance_class = Rc::new(RefCell::new(Class {
+    let instance_class = instance_class_ctxt.heap.allocate(RefCell::new(Class {
         name: instance_class_ctxt.name.clone(),
-        class: MaybeWeak::Strong(static_class.clone()),
-        super_class: Weak::new(),
+        class: Some(static_class.clone()),
+        super_class: None,
         locals: IndexMap::new(),
         methods: IndexMap::new(),
         is_static: false,
@@ -685,11 +730,9 @@ pub fn compile_class(
         let signature = instance_class_ctxt
             .interner
             .intern(method.signature.as_str());
-        let mut method = compile_method(&mut instance_class_ctxt, method)?;
-        method.holder = Rc::downgrade(&instance_class);
-        instance_class_ctxt
-            .methods
-            .insert(signature, Rc::new(method));
+        let method = compile_method(&mut instance_class_ctxt, &instance_class, method)?;
+        let method = instance_class_ctxt.heap.allocate(method);
+        instance_class_ctxt.methods.insert(signature, method);
     }
 
     if let Some(primitives) = primitives::get_instance_primitives(&defn.name) {
@@ -705,12 +748,11 @@ pub fn compile_class(
             let method = Method {
                 signature: signature.to_string(),
                 kind: MethodKind::Primitive(primitive),
-                holder: Rc::downgrade(&instance_class),
+                holder: instance_class.clone(),
             };
             let signature = instance_class_ctxt.interner.intern(signature);
-            instance_class_ctxt
-                .methods
-                .insert(signature, Rc::new(method));
+            let method = instance_class_ctxt.heap.allocate(method);
+            instance_class_ctxt.methods.insert(signature, method);
         }
     }
 

--- a/som-interpreter-bc/src/compiler.rs
+++ b/som-interpreter-bc/src/compiler.rs
@@ -579,8 +579,8 @@ fn compile_block(outer: &mut dyn GenCtxt, defn: &ast::Block) -> Option<Block> {
             .map(|name| ctxt.intern_symbol(&name))
             .collect()
     };
-    let literals = ctxt.literals.into_iter().collect();
-    let body = ctxt.body.unwrap_or_default();
+    let literals = std::mem::take(&mut ctxt.literals).into_iter().collect();
+    let body = ctxt.body.take().unwrap_or_default();
     let nb_params = ctxt.args.len();
 
     let block = Block {

--- a/som-interpreter-bc/src/hashcode.rs
+++ b/som-interpreter-bc/src/hashcode.rs
@@ -100,11 +100,7 @@ impl Hash for Block {
 
 impl Hash for Method {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
-        if let Some(holder) = self.holder().upgrade() {
-            holder.borrow().hash(hasher);
-        } else {
-            hasher.write(b"??");
-        }
+        self.holder.borrow().hash(hasher);
         hasher.write(b">>");
         self.signature.hash(hasher);
     }

--- a/som-interpreter-bc/src/instance.rs
+++ b/som-interpreter-bc/src/instance.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use som_gc::Trace;
+
 use crate::class::Class;
 use crate::value::Value;
 use crate::SOMRef;
@@ -11,6 +13,14 @@ pub struct Instance {
     pub class: SOMRef<Class>,
     /// This instance's locals.
     pub locals: Vec<Value>,
+}
+
+impl Trace for Instance {
+    #[inline]
+    fn trace(&self) {
+        self.class.trace();
+        self.locals.trace();
+    }
 }
 
 impl Instance {

--- a/som-interpreter-bc/src/interpreter.rs
+++ b/som-interpreter-bc/src/interpreter.rs
@@ -448,14 +448,12 @@ impl Interpreter {
                     let maybe_found = unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
 
                     match maybe_found {
-                        Some((receiver, method)) if *receiver == RefCell::as_ptr(&class) => {
+                        Some((receiver, method)) if *receiver == Gc::as_ptr(class) => {
                             Some(Gc::clone(method))
                         }
                         place @ None => {
                             let found = class.borrow().lookup_method(signature);
-                            *place = found
-                                .clone()
-                                .map(|method| (class.as_ptr() as *const _, method));
+                            *place = found.clone().map(|method| (Gc::as_ptr(class), method));
                             found
                         }
                         _ => class.borrow().lookup_method(signature),
@@ -471,14 +469,12 @@ impl Interpreter {
                         let maybe_found = unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
 
                         match maybe_found {
-                            Some((receiver, method)) if *receiver == RefCell::as_ptr(&class) => {
+                            Some((receiver, method)) if *receiver == Gc::as_ptr(class) => {
                                 Some(Gc::clone(method))
                             }
                             place @ None => {
                                 let found = class.borrow().lookup_method(signature);
-                                *place = found
-                                    .clone()
-                                    .map(|method| (class.as_ptr() as *const _, method));
+                                *place = found.clone().map(|method| (Gc::as_ptr(class), method));
                                 found
                             }
                             _ => class.borrow().lookup_method(signature),

--- a/som-interpreter-bc/src/interpreter.rs
+++ b/som-interpreter-bc/src/interpreter.rs
@@ -1,8 +1,8 @@
 use std::cell::RefCell;
-use std::rc::Rc;
 use std::time::Instant;
 
 use som_core::bytecode::Bytecode;
+use som_gc::{Gc, GcHeap, Trace};
 
 use crate::block::Block;
 use crate::class::Class;
@@ -18,7 +18,7 @@ const INT_0: Value = Value::Integer(0);
 const INT_1: Value = Value::Integer(1);
 
 macro_rules! send {
-    ($interp:expr, $universe:expr, $frame:expr, $lit_idx:expr, $nb_params:expr, $bytecode_idx:expr) => {{
+    ($interp:expr, $universe:expr, $heap:expr, $frame:expr, $lit_idx:expr, $nb_params:expr, $bytecode_idx:expr) => {{
         let literal = $frame.borrow().lookup_constant($lit_idx as usize).unwrap();
         let Literal::Symbol(symbol) = literal else {
             return None;
@@ -35,12 +35,19 @@ macro_rules! send {
             let receiver_class = receiver.class($universe);
             resolve_method($frame, &receiver_class, symbol, $bytecode_idx)
         };
-        do_send($interp, $universe, method, symbol, nb_params as usize);
+        do_send(
+            $interp,
+            $universe,
+            $heap,
+            method,
+            symbol,
+            nb_params as usize,
+        );
     }};
 }
 
 macro_rules! super_send {
-    ($interp:expr, $universe:expr, $frame_expr:expr, $lit_idx:expr, $nb_params:expr, $bytecode_idx:expr) => {{
+    ($interp:expr, $universe:expr, $heap:expr, $frame_expr:expr, $lit_idx:expr, $nb_params:expr, $bytecode_idx:expr) => {{
         let literal = $frame_expr
             .borrow()
             .lookup_constant($lit_idx as usize)
@@ -60,7 +67,14 @@ macro_rules! super_send {
             let super_class = holder.borrow().super_class().unwrap();
             resolve_method($frame_expr, &super_class, symbol, $bytecode_idx)
         };
-        do_send($interp, $universe, method, symbol, nb_params as usize);
+        do_send(
+            $interp,
+            $universe,
+            $heap,
+            method,
+            symbol,
+            nb_params as usize,
+        );
     }};
 }
 
@@ -73,6 +87,14 @@ pub struct Interpreter {
     pub start_time: Instant,
 }
 
+impl Trace for Interpreter {
+    #[inline]
+    fn trace(&self) {
+        self.frames.trace();
+        self.stack.trace();
+    }
+}
+
 impl Interpreter {
     pub fn new() -> Self {
         Self {
@@ -82,8 +104,8 @@ impl Interpreter {
         }
     }
 
-    pub fn push_frame(&mut self, kind: FrameKind) -> SOMRef<Frame> {
-        let frame = Rc::new(RefCell::new(Frame::from_kind(kind)));
+    pub fn push_frame(&mut self, heap: &mut GcHeap, kind: FrameKind) -> SOMRef<Frame> {
+        let frame = heap.allocate(RefCell::new(Frame::from_kind(kind)));
         self.frames.push(frame.clone());
         frame
     }
@@ -96,25 +118,29 @@ impl Interpreter {
         self.frames.last()
     }
 
-    pub fn run(&mut self, universe: &mut Universe) -> Option<Value> {
+    pub fn run(&mut self, heap: &mut GcHeap, universe: &mut Universe) -> Option<Value> {
         loop {
-            let frame = match self.current_frame() {
-                Some(frame) => frame,
-                None => return Some(self.stack.pop().unwrap_or(Value::Nil)),
+            heap.maybe_collect_garbage(|| {
+                self.trace();
+                universe.trace();
+            });
+
+            let Some(frame) = self.current_frame() else {
+                return Some(self.stack.pop().unwrap_or(Value::Nil));
             };
 
-            let bytecode_idx = frame.borrow().bytecode_idx;
-            let opt_bytecode = frame.borrow().get_current_bytecode();
-            let bytecode = match opt_bytecode {
-                Some(bytecode) => bytecode,
-                None => {
-                    self.pop_frame();
-                    self.stack.push(Value::Nil);
-                    continue;
-                }
+            let mut cur_frame = frame.borrow_mut();
+            let Some(bytecode) = cur_frame.get_current_bytecode() else {
+                drop(cur_frame);
+                self.pop_frame();
+                self.stack.push(Value::Nil);
+                continue;
             };
 
-            frame.borrow_mut().bytecode_idx += 1;
+            let bytecode_idx = cur_frame.bytecode_idx;
+            cur_frame.bytecode_idx += 1;
+
+            drop(cur_frame);
 
             match bytecode {
                 Bytecode::Halt => {
@@ -168,27 +194,27 @@ impl Interpreter {
                         Literal::Block(blk) => Block::clone(&blk),
                         _ => return None,
                     };
-                    block.frame.replace(Rc::clone(&frame));
-                    self.stack.push(Value::Block(Rc::new(block)));
+                    block.frame.replace(Gc::clone(&frame));
+                    self.stack.push(Value::Block(heap.allocate(block)));
                 }
                 Bytecode::PushConstant(idx) => {
                     let literal = frame.borrow().lookup_constant(idx as usize).unwrap();
-                    let value = convert_literal(frame, literal).unwrap();
+                    let value = convert_literal(heap, &frame, literal).unwrap();
                     self.stack.push(value);
                 }
                 Bytecode::PushConstant0 => {
                     let literal = frame.borrow().lookup_constant(0).unwrap();
-                    let value = convert_literal(frame, literal).unwrap();
+                    let value = convert_literal(heap, &frame, literal).unwrap();
                     self.stack.push(value);
                 }
                 Bytecode::PushConstant1 => {
                     let literal = frame.borrow().lookup_constant(1).unwrap();
-                    let value = convert_literal(frame, literal).unwrap();
+                    let value = convert_literal(heap, &frame, literal).unwrap();
                     self.stack.push(value);
                 }
                 Bytecode::PushConstant2 => {
                     let literal = frame.borrow().lookup_constant(2).unwrap();
-                    let value = convert_literal(frame, literal).unwrap();
+                    let value = convert_literal(heap, &frame, literal).unwrap();
                     self.stack.push(value);
                 }
                 Bytecode::PushGlobal(idx) => {
@@ -201,7 +227,9 @@ impl Interpreter {
                         self.stack.push(value);
                     } else {
                         let self_value = frame.borrow().get_self();
-                        universe.unknown_global(self, self_value, symbol).unwrap();
+                        universe
+                            .unknown_global(self, heap, self_value, symbol)
+                            .unwrap();
                     }
                 }
                 Bytecode::Push0 => {
@@ -263,28 +291,29 @@ impl Interpreter {
                     }
                 }
                 Bytecode::Send1(idx) => {
-                    send! {self, universe, frame, idx, Some(0), bytecode_idx} // Send1 => receiver + 0 args, so we pass Some(0)
+                    // Send1 => receiver + 0 args, so we pass Some(0)
+                    send!(self, universe, heap, frame, idx, Some(0), bytecode_idx)
                 }
                 Bytecode::Send2(idx) => {
-                    send! {self, universe, frame, idx, Some(1), bytecode_idx}
+                    send!(self, universe, heap, frame, idx, Some(1), bytecode_idx)
                 }
                 Bytecode::Send3(idx) => {
-                    send! {self, universe, frame, idx, Some(2), bytecode_idx}
+                    send!(self, universe, heap, frame, idx, Some(2), bytecode_idx)
                 }
                 Bytecode::SendN(idx) => {
-                    send! {self, universe, frame, idx, None, bytecode_idx}
+                    send!(self, universe, heap, frame, idx, None, bytecode_idx)
                 }
                 Bytecode::SuperSend1(idx) => {
-                    super_send! {self, universe, frame, idx, Some(0), bytecode_idx}
+                    super_send!(self, universe, heap, frame, idx, Some(0), bytecode_idx)
                 }
                 Bytecode::SuperSend2(idx) => {
-                    super_send! {self, universe, frame, idx, Some(1), bytecode_idx}
+                    super_send!(self, universe, heap, frame, idx, Some(1), bytecode_idx)
                 }
                 Bytecode::SuperSend3(idx) => {
-                    super_send! {self, universe, frame, idx, Some(2), bytecode_idx}
+                    super_send!(self, universe, heap, frame, idx, Some(2), bytecode_idx)
                 }
                 Bytecode::SuperSendN(idx) => {
-                    super_send! {self, universe, frame, idx, None, bytecode_idx}
+                    super_send!(self, universe, heap, frame, idx, None, bytecode_idx)
                 }
                 Bytecode::ReturnLocal => {
                     let value = self.stack.pop().unwrap();
@@ -299,7 +328,7 @@ impl Interpreter {
                         .frames
                         .iter()
                         .rev()
-                        .position(|live_frame| Rc::ptr_eq(&live_frame, &method_frame));
+                        .position(|live_frame| Gc::ptr_eq(&live_frame, &method_frame));
 
                     if let Some(count) = escaped_frames {
                         (0..count).for_each(|_| self.pop_frame());
@@ -317,7 +346,7 @@ impl Interpreter {
                             }
                         };
                         // TODO: should we call `doesNotUnderstand:` here ?
-                        universe.escaped_block(self, instance, block).expect(
+                        universe.escaped_block(self, heap, instance, block).expect(
                             "A block has escaped and `escapedBlock:` is not defined on receiver",
                         );
                     }
@@ -328,7 +357,8 @@ impl Interpreter {
         fn do_send(
             interpreter: &mut Interpreter,
             universe: &mut Universe,
-            method: Option<Rc<Method>>,
+            heap: &mut GcHeap,
+            method: Option<Gc<Method>>,
             symbol: Interned,
             nb_params: usize,
         ) {
@@ -343,7 +373,7 @@ impl Interpreter {
 
                 args.reverse();
 
-                universe.does_not_understand(interpreter, self_value, symbol, args)
+                universe.does_not_understand(interpreter, heap, self_value, symbol, args)
                     .expect(
                         "A message cannot be handled and `doesNotUnderstand:arguments:` is not defined on receiver"
                     );
@@ -351,7 +381,7 @@ impl Interpreter {
                 return;
             };
 
-            match method.kind() {
+            match &method.kind {
                 MethodKind::Defined(_) => {
                     let mut args = Vec::with_capacity(nb_params + 1);
 
@@ -364,16 +394,18 @@ impl Interpreter {
 
                     args.reverse();
 
-                    let holder = method.holder.upgrade().unwrap();
-                    let frame = interpreter.push_frame(FrameKind::Method {
-                        self_value,
-                        method,
-                        holder,
-                    });
+                    let frame = interpreter.push_frame(
+                        heap,
+                        FrameKind::Method {
+                            holder: method.holder.clone(),
+                            self_value,
+                            method,
+                        },
+                    );
                     frame.borrow_mut().args = args;
                 }
                 MethodKind::Primitive(func) => {
-                    func(interpreter, universe);
+                    func(interpreter, heap, universe);
                 }
                 MethodKind::NotImplemented(err) => {
                     let self_value = interpreter.stack.iter().nth_back(nb_params).unwrap();
@@ -392,7 +424,7 @@ impl Interpreter {
             class: &SOMRef<Class>,
             signature: Interned,
             bytecode_idx: usize,
-        ) -> Option<Rc<Method>> {
+        ) -> Option<Gc<Method>> {
             match frame.borrow().kind() {
                 FrameKind::Block { block } => {
                     let mut inline_cache = block.blk_info.inline_cache.borrow_mut();
@@ -403,8 +435,8 @@ impl Interpreter {
                     let maybe_found = unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
 
                     match maybe_found {
-                        Some((receiver, method)) if *receiver == class.as_ptr() => {
-                            Some(Rc::clone(method))
+                        Some((receiver, method)) if *receiver == RefCell::as_ptr(&class) => {
+                            Some(Gc::clone(method))
                         }
                         place @ None => {
                             let found = class.borrow().lookup_method(signature);
@@ -417,7 +449,7 @@ impl Interpreter {
                     }
                 }
                 FrameKind::Method { method, .. } => {
-                    if let MethodKind::Defined(env) = method.kind() {
+                    if let MethodKind::Defined(env) = &method.kind {
                         let mut inline_cache = env.inline_cache.borrow_mut();
 
                         // SAFETY: this access is actually safe because the bytecode compiler
@@ -426,8 +458,8 @@ impl Interpreter {
                         let maybe_found = unsafe { inline_cache.get_unchecked_mut(bytecode_idx) };
 
                         match maybe_found {
-                            Some((receiver, method)) if *receiver == class.as_ptr() => {
-                                Some(Rc::clone(method))
+                            Some((receiver, method)) if *receiver == RefCell::as_ptr(&class) => {
+                                Some(Gc::clone(method))
                             }
                             place @ None => {
                                 let found = class.borrow().lookup_method(signature);
@@ -445,7 +477,11 @@ impl Interpreter {
             }
         }
 
-        fn convert_literal(frame: &SOMRef<Frame>, literal: Literal) -> Option<Value> {
+        fn convert_literal(
+            heap: &mut GcHeap,
+            frame: &SOMRef<Frame>,
+            literal: Literal,
+        ) -> Option<Value> {
             let value = match literal {
                 Literal::Symbol(sym) => Value::Symbol(sym),
                 Literal::String(val) => Value::String(val),
@@ -459,11 +495,11 @@ impl Interpreter {
                             frame
                                 .borrow()
                                 .lookup_constant(idx as usize)
-                                .and_then(|lit| convert_literal(frame, lit))
+                                .and_then(|lit| convert_literal(heap, frame, lit))
                         })
                         .collect::<Option<Vec<_>>>()
                         .unwrap();
-                    Value::Array(Rc::new(RefCell::new(arr)))
+                    Value::Array(heap.allocate(RefCell::new(arr)))
                 }
                 Literal::Block(val) => Value::Block(val),
             };

--- a/som-interpreter-bc/src/interpreter.rs
+++ b/som-interpreter-bc/src/interpreter.rs
@@ -43,6 +43,10 @@ macro_rules! send {
             symbol,
             nb_params as usize,
         );
+        $heap.maybe_collect_garbage(|| {
+            $interp.trace();
+            $universe.trace();
+        });
     }};
 }
 
@@ -75,6 +79,10 @@ macro_rules! super_send {
             symbol,
             nb_params as usize,
         );
+        $heap.maybe_collect_garbage(|| {
+            $interp.trace();
+            $universe.trace();
+        });
     }};
 }
 
@@ -120,12 +128,12 @@ impl Interpreter {
 
     pub fn run(&mut self, heap: &mut GcHeap, universe: &mut Universe) -> Option<Value> {
         loop {
-            heap.maybe_collect_garbage(|| {
-                self.trace();
-                universe.trace();
-            });
-
             let Some(frame) = self.current_frame() else {
+                heap.maybe_collect_garbage(|| {
+                    self.trace();
+                    universe.trace();
+                });
+
                 return Some(self.stack.pop().unwrap_or(Value::Nil));
             };
 
@@ -144,6 +152,11 @@ impl Interpreter {
 
             match bytecode {
                 Bytecode::Halt => {
+                    heap.maybe_collect_garbage(|| {
+                        self.trace();
+                        universe.trace();
+                    });
+
                     return Some(Value::Nil);
                 }
                 Bytecode::Dup => {

--- a/som-interpreter-bc/src/lib.rs
+++ b/som-interpreter-bc/src/lib.rs
@@ -3,7 +3,8 @@
 //!
 
 use std::cell::RefCell;
-use std::rc::{Rc, Weak};
+
+use som_gc::Gc;
 
 /// Facilities for manipulating blocks.
 pub mod block;
@@ -32,7 +33,5 @@ pub mod universe;
 /// Facilities for manipulating values.
 pub mod value;
 
-/// A strong and owning reference to an object.
-pub type SOMRef<T> = Rc<RefCell<T>>;
-/// A weak reference to an object.
-pub type SOMWeakRef<T> = Weak<RefCell<T>>;
+/// A reference to a GC-ed mutable object.
+pub type SOMRef<T> = Gc<RefCell<T>>;

--- a/som-interpreter-bc/src/main.rs
+++ b/som-interpreter-bc/src/main.rs
@@ -16,7 +16,7 @@ use som_gc::{GcHeap, GcParams};
 
 use som_interpreter_bc::disassembler::disassemble_method_body;
 use som_interpreter_bc::interpreter::Interpreter;
-use som_interpreter_bc::method::{Method, MethodKind};
+use som_interpreter_bc::method::MethodKind;
 use som_interpreter_bc::universe::Universe;
 use som_interpreter_bc::value::Value;
 
@@ -108,8 +108,7 @@ fn main() -> anyhow::Result<()> {
 
     let args = std::iter::once(String::from(file_stem))
         .chain(opts.args.iter().cloned())
-        .map(Rc::new)
-        .map(Value::String)
+        .map(|it| Value::String(heap.allocate(it)))
         .collect();
 
     universe
@@ -174,7 +173,7 @@ fn disassemble_class(heap: &mut GcHeap, opts: Options) -> anyhow::Result<()> {
 
     let class = universe.load_class(heap, file_stem)?;
 
-    let methods: Vec<Rc<Method>> = if opts.args.is_empty() {
+    let methods: Vec<_> = if opts.args.is_empty() {
         class.borrow().methods.values().cloned().collect()
     } else {
         opts.args

--- a/som-interpreter-bc/src/method.rs
+++ b/som-interpreter-bc/src/method.rs
@@ -62,7 +62,6 @@ impl Trace for MethodKind {
 impl Trace for MethodEnv {
     #[inline]
     fn trace(&self) {
-        self.locals.trace();
         self.literals.trace();
         self.inline_cache.trace();
     }

--- a/som-interpreter-bc/src/method.rs
+++ b/som-interpreter-bc/src/method.rs
@@ -19,7 +19,7 @@ pub struct MethodEnv {
     pub locals: Vec<Interned>,
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
-    pub inline_cache: RefCell<Vec<Option<(*const Class, Gc<Method>)>>>,
+    pub inline_cache: RefCell<Vec<Option<(*const RefCell<Class>, Gc<Method>)>>>,
 }
 
 /// The kind of a class method.

--- a/som-interpreter-bc/src/method.rs
+++ b/som-interpreter-bc/src/method.rs
@@ -1,8 +1,8 @@
 use std::cell::RefCell;
 use std::fmt;
-use std::rc::Rc;
 
 use som_core::bytecode::Bytecode;
+use som_gc::{Gc, GcHeap, Trace};
 
 use crate::class::Class;
 use crate::compiler::Literal;
@@ -12,14 +12,14 @@ use crate::interpreter::Interpreter;
 use crate::primitives::PrimitiveFn;
 use crate::universe::Universe;
 use crate::value::Value;
-use crate::{SOMRef, SOMWeakRef};
+use crate::SOMRef;
 
 #[derive(Clone)]
 pub struct MethodEnv {
     pub locals: Vec<Interned>,
     pub literals: Vec<Literal>,
     pub body: Vec<Bytecode>,
-    pub inline_cache: RefCell<Vec<Option<(*const Class, Rc<Method>)>>>,
+    pub inline_cache: RefCell<Vec<Option<(*const Class, Gc<Method>)>>>,
 }
 
 /// The kind of a class method.
@@ -44,8 +44,36 @@ impl MethodKind {
 #[derive(Clone)]
 pub struct Method {
     pub kind: MethodKind,
-    pub holder: SOMWeakRef<Class>,
+    pub holder: SOMRef<Class>,
     pub signature: String,
+}
+
+impl Trace for MethodKind {
+    #[inline]
+    fn trace(&self) {
+        match self {
+            MethodKind::Defined(env) => env.trace(),
+            MethodKind::Primitive(_) => {}
+            MethodKind::NotImplemented(_) => {}
+        }
+    }
+}
+
+impl Trace for MethodEnv {
+    #[inline]
+    fn trace(&self) {
+        self.locals.trace();
+        self.literals.trace();
+        self.inline_cache.trace();
+    }
+}
+
+impl Trace for Method {
+    #[inline]
+    fn trace(&self) {
+        self.kind.trace();
+        self.holder.trace();
+    }
 }
 
 impl Method {
@@ -55,14 +83,6 @@ impl Method {
         } else {
             universe.method_class()
         }
-    }
-
-    pub fn kind(&self) -> &MethodKind {
-        &self.kind
-    }
-
-    pub fn holder(&self) -> &SOMWeakRef<Class> {
-        &self.holder
     }
 
     pub fn signature(&self) -> &str {
@@ -75,29 +95,29 @@ impl Method {
     }
 
     pub fn invoke(
-        self: Rc<Self>,
+        this: Gc<Self>,
         interpreter: &mut Interpreter,
+        heap: &mut GcHeap,
         universe: &mut Universe,
         receiver: Value,
         mut args: Vec<Value>,
     ) {
-        match self.kind() {
+        match &this.kind {
             MethodKind::Defined(_) => {
-                let holder = self.holder().upgrade().unwrap();
                 let kind = FrameKind::Method {
-                    method: self,
-                    holder,
+                    holder: this.holder.clone(),
+                    method: this,
                     self_value: receiver.clone(),
                 };
 
-                let frame = interpreter.push_frame(kind);
+                let frame = interpreter.push_frame(heap, kind);
                 frame.borrow_mut().args.push(receiver);
                 frame.borrow_mut().args.append(&mut args);
             }
             MethodKind::Primitive(func) => {
                 interpreter.stack.push(receiver);
                 interpreter.stack.append(&mut args);
-                func(interpreter, universe)
+                func(interpreter, heap, universe)
             }
             MethodKind::NotImplemented(_) => todo!(),
         }
@@ -109,8 +129,8 @@ impl fmt::Display for Method {
         write!(
             f,
             "#{}>>#{} = ",
-            self.holder.upgrade().unwrap().borrow().name(),
-            self.signature
+            self.holder.borrow().name(),
+            self.signature,
         )?;
         match &self.kind {
             MethodKind::Defined(env) => {

--- a/som-interpreter-bc/src/primitives/blocks.rs
+++ b/som-interpreter-bc/src/primitives/blocks.rs
@@ -1,3 +1,5 @@
+use som_gc::GcHeap;
+
 use crate::frame::FrameKind;
 use crate::interpreter::Interpreter;
 use crate::primitives::PrimitiveFn;
@@ -15,7 +17,7 @@ pub mod block1 {
     ];
     pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
-    fn value(interpreter: &mut Interpreter, _: &mut Universe) {
+    fn value(interpreter: &mut Interpreter, heap: &mut GcHeap, _: &mut Universe) {
         const SIGNATURE: &str = "Block1>>#value";
 
         expect_args!(SIGNATURE, interpreter, [
@@ -26,10 +28,10 @@ pub mod block1 {
             block: block.clone(),
         };
 
-        interpreter.push_frame(kind);
+        interpreter.push_frame(heap, kind);
     }
 
-    fn restart(interpreter: &mut Interpreter, _: &mut Universe) {
+    fn restart(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
         const SIGNATURE: &str = "Block>>#restart";
 
         expect_args!(SIGNATURE, interpreter, [Value::Block(_)]);
@@ -62,7 +64,7 @@ pub mod block2 {
     pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[("value:", self::value, true)];
     pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
-    fn value(interpreter: &mut Interpreter, _: &mut Universe) {
+    fn value(interpreter: &mut Interpreter, heap: &mut GcHeap, _: &mut Universe) {
         const SIGNATURE: &str = "Block2>>#value:";
 
         expect_args!(SIGNATURE, interpreter, [
@@ -74,7 +76,7 @@ pub mod block2 {
             block: block.clone(),
         };
 
-        let frame = interpreter.push_frame(kind);
+        let frame = interpreter.push_frame(heap, kind);
         frame.borrow_mut().args.push(argument);
     }
 
@@ -103,7 +105,7 @@ pub mod block3 {
         &[("value:with:", self::value_with, true)];
     pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
-    fn value_with(interpreter: &mut Interpreter, _: &mut Universe) {
+    fn value_with(interpreter: &mut Interpreter, heap: &mut GcHeap, _: &mut Universe) {
         const SIGNATURE: &str = "Block3>>#value:with:";
 
         expect_args!(SIGNATURE, interpreter, [
@@ -116,7 +118,7 @@ pub mod block3 {
             block: block.clone(),
         };
 
-        let frame = interpreter.push_frame(kind);
+        let frame = interpreter.push_frame(heap, kind);
         frame.borrow_mut().args.push(argument1);
         frame.borrow_mut().args.push(argument2);
     }

--- a/som-interpreter-bc/src/primitives/double.rs
+++ b/som-interpreter-bc/src/primitives/double.rs
@@ -1,6 +1,6 @@
-use std::rc::Rc;
-
 use num_traits::ToPrimitive;
+
+use som_gc::GcHeap;
 
 use crate::interpreter::Interpreter;
 use crate::primitives::PrimitiveFn;
@@ -50,7 +50,7 @@ macro_rules! promote {
     };
 }
 
-fn from_string(interpreter: &mut Interpreter, _: &mut Universe) {
+fn from_string(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#fromString:";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -64,7 +64,7 @@ fn from_string(interpreter: &mut Interpreter, _: &mut Universe) {
     }
 }
 
-fn as_string(interpreter: &mut Interpreter, _: &mut Universe) {
+fn as_string(interpreter: &mut Interpreter, heap: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#asString";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -75,10 +75,10 @@ fn as_string(interpreter: &mut Interpreter, _: &mut Universe) {
 
     interpreter
         .stack
-        .push(Value::String(Rc::new(value.to_string())));
+        .push(Value::String(heap.allocate(value.to_string())));
 }
 
-fn as_integer(interpreter: &mut Interpreter, _: &mut Universe) {
+fn as_integer(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#asInteger";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -88,7 +88,7 @@ fn as_integer(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Integer(value.trunc() as i64));
 }
 
-fn sqrt(interpreter: &mut Interpreter, _: &mut Universe) {
+fn sqrt(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#sqrt";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -100,7 +100,7 @@ fn sqrt(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Double(value.sqrt()));
 }
 
-fn round(interpreter: &mut Interpreter, _: &mut Universe) {
+fn round(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#round";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -112,7 +112,7 @@ fn round(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Double(value.round()));
 }
 
-fn cos(interpreter: &mut Interpreter, _: &mut Universe) {
+fn cos(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#cos";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -124,7 +124,7 @@ fn cos(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Double(value.cos()));
 }
 
-fn sin(interpreter: &mut Interpreter, _: &mut Universe) {
+fn sin(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#sin";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -136,7 +136,7 @@ fn sin(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Double(value.sin()));
 }
 
-fn eq(interpreter: &mut Interpreter, _: &mut Universe) {
+fn eq(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#=";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -149,7 +149,7 @@ fn eq(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Boolean(a == b));
 }
 
-fn lt(interpreter: &mut Interpreter, _: &mut Universe) {
+fn lt(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#<";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -163,7 +163,7 @@ fn lt(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Boolean(a < b));
 }
 
-fn plus(interpreter: &mut Interpreter, _: &mut Universe) {
+fn plus(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#+";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -177,7 +177,7 @@ fn plus(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Double(a + b));
 }
 
-fn minus(interpreter: &mut Interpreter, _: &mut Universe) {
+fn minus(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#-";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -191,7 +191,7 @@ fn minus(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Double(a - b));
 }
 
-fn times(interpreter: &mut Interpreter, _: &mut Universe) {
+fn times(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#*";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -205,7 +205,7 @@ fn times(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Double(a * b));
 }
 
-fn divide(interpreter: &mut Interpreter, _: &mut Universe) {
+fn divide(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#//";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -219,7 +219,7 @@ fn divide(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Double(a / b));
 }
 
-fn modulo(interpreter: &mut Interpreter, _: &mut Universe) {
+fn modulo(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#%";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -233,7 +233,7 @@ fn modulo(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Double(a % b));
 }
 
-fn positive_infinity(interpreter: &mut Interpreter, _: &mut Universe) {
+fn positive_infinity(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Double>>#positiveInfinity";
 
     expect_args!(SIGNATURE, interpreter, [_]);

--- a/som-interpreter-bc/src/primitives/integer.rs
+++ b/som-interpreter-bc/src/primitives/integer.rs
@@ -1,9 +1,9 @@
-use std::rc::Rc;
-
 use num_bigint::{BigInt, Sign};
 use num_traits::ToPrimitive;
 use rand::distributions::Uniform;
 use rand::Rng;
+
+use som_gc::GcHeap;
 
 use crate::interpreter::Interpreter;
 use crate::primitives::PrimitiveFn;
@@ -45,7 +45,7 @@ macro_rules! demote {
     }};
 }
 
-fn from_string(interpreter: &mut Interpreter, universe: &mut Universe) {
+fn from_string(interpreter: &mut Interpreter, _: &mut GcHeap, universe: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#fromString:";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -71,7 +71,7 @@ fn from_string(interpreter: &mut Interpreter, universe: &mut Universe) {
     }
 }
 
-fn as_string(interpreter: &mut Interpreter, _: &mut Universe) {
+fn as_string(interpreter: &mut Interpreter, heap: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#asString";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -84,13 +84,10 @@ fn as_string(interpreter: &mut Interpreter, _: &mut Universe) {
         _ => panic!("'{}': wrong types", SIGNATURE),
     };
 
-    {
-        interpreter.stack.push(Value::String(Rc::new(value)));
-        return;
-    }
+    interpreter.stack.push(Value::String(heap.allocate(value)));
 }
 
-fn as_double(interpreter: &mut Interpreter, _: &mut Universe) {
+fn as_double(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#asDouble";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -112,7 +109,7 @@ fn as_double(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-fn at_random(interpreter: &mut Interpreter, _: &mut Universe) {
+fn at_random(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#atRandom";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -138,7 +135,7 @@ fn at_random(interpreter: &mut Interpreter, _: &mut Universe) {
     }
 }
 
-fn as_32bit_signed_value(interpreter: &mut Interpreter, _: &mut Universe) {
+fn as_32bit_signed_value(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#as32BitSignedValue";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -160,7 +157,7 @@ fn as_32bit_signed_value(interpreter: &mut Interpreter, _: &mut Universe) {
     }
 }
 
-fn as_32bit_unsigned_value(interpreter: &mut Interpreter, _: &mut Universe) {
+fn as_32bit_unsigned_value(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#as32BitUnsignedValue";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -182,7 +179,7 @@ fn as_32bit_unsigned_value(interpreter: &mut Interpreter, _: &mut Universe) {
     }
 }
 
-fn plus(interpreter: &mut Interpreter, _: &mut Universe) {
+fn plus(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#+";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -218,7 +215,7 @@ fn plus(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-fn minus(interpreter: &mut Interpreter, _: &mut Universe) {
+fn minus(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#-";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -262,7 +259,7 @@ fn minus(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-fn times(interpreter: &mut Interpreter, _: &mut Universe) {
+fn times(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#*";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -298,7 +295,7 @@ fn times(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-fn divide(interpreter: &mut Interpreter, _: &mut Universe) {
+fn divide(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#/";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -342,7 +339,7 @@ fn divide(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-fn divide_float(interpreter: &mut Interpreter, _: &mut Universe) {
+fn divide_float(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#//";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -379,7 +376,7 @@ fn divide_float(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(Value::Double(a / b));
 }
 
-fn modulo(interpreter: &mut Interpreter, _: &mut Universe) {
+fn modulo(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#%";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -395,7 +392,7 @@ fn modulo(interpreter: &mut Interpreter, _: &mut Universe) {
     }
 }
 
-fn remainder(interpreter: &mut Interpreter, _: &mut Universe) {
+fn remainder(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#rem:";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -411,7 +408,7 @@ fn remainder(interpreter: &mut Interpreter, _: &mut Universe) {
     }
 }
 
-fn sqrt(interpreter: &mut Interpreter, _: &mut Universe) {
+fn sqrt(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#sqrt";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -436,7 +433,7 @@ fn sqrt(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-fn bitand(interpreter: &mut Interpreter, _: &mut Universe) {
+fn bitand(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#&";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -456,7 +453,7 @@ fn bitand(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-fn bitxor(interpreter: &mut Interpreter, _: &mut Universe) {
+fn bitxor(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#bitXor:";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -476,7 +473,7 @@ fn bitxor(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-fn lt(interpreter: &mut Interpreter, _: &mut Universe) {
+fn lt(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#<";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -498,7 +495,7 @@ fn lt(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-fn eq(interpreter: &mut Interpreter, _: &mut Universe) {
+fn eq(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#=";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -518,7 +515,7 @@ fn eq(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-fn shift_left(interpreter: &mut Interpreter, _: &mut Universe) {
+fn shift_left(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#<<";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -538,7 +535,7 @@ fn shift_left(interpreter: &mut Interpreter, _: &mut Universe) {
     interpreter.stack.push(value);
 }
 
-fn shift_right(interpreter: &mut Interpreter, _: &mut Universe) {
+fn shift_right(interpreter: &mut Interpreter, _: &mut GcHeap, _: &mut Universe) {
     const SIGNATURE: &str = "Integer>>#>>";
 
     expect_args!(SIGNATURE, interpreter, [

--- a/som-interpreter-bc/src/primitives/mod.rs
+++ b/som-interpreter-bc/src/primitives/mod.rs
@@ -19,13 +19,16 @@ pub mod symbol;
 /// Primitives for the **System** class.
 pub mod system;
 
+use som_gc::GcHeap;
+
 pub use self::blocks::{block1, block2, block3};
 
 use crate::interpreter::Interpreter;
 use crate::universe::Universe;
 
 /// A interpreter primitive (just a bare function pointer).
-pub type PrimitiveFn = fn(interpreter: &mut Interpreter, universe: &mut Universe);
+pub type PrimitiveFn =
+    fn(interpreter: &mut Interpreter, heap: &mut GcHeap, universe: &mut Universe);
 
 #[macro_export]
 macro_rules! reverse {

--- a/som-interpreter-bc/src/primitives/string.rs
+++ b/som-interpreter-bc/src/primitives/string.rs
@@ -1,7 +1,8 @@
 use std::collections::hash_map::DefaultHasher;
 use std::convert::TryFrom;
 use std::hash::Hasher;
-use std::rc::Rc;
+
+use som_gc::GcHeap;
 
 use crate::interpreter::Interpreter;
 use crate::primitives::PrimitiveFn;
@@ -22,7 +23,7 @@ pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[
 ];
 pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
-fn length(interpreter: &mut Interpreter, universe: &mut Universe) {
+fn length(interpreter: &mut Interpreter, _: &mut GcHeap, universe: &mut Universe) {
     const SIGNATURE: &str = "String>>#length";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -41,7 +42,7 @@ fn length(interpreter: &mut Interpreter, universe: &mut Universe) {
     }
 }
 
-fn hashcode(interpreter: &mut Interpreter, universe: &mut Universe) {
+fn hashcode(interpreter: &mut Interpreter, _: &mut GcHeap, universe: &mut Universe) {
     const SIGNATURE: &str = "String>>#hashcode";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -68,7 +69,7 @@ fn hashcode(interpreter: &mut Interpreter, universe: &mut Universe) {
         .push(Value::Integer((hasher.finish() as i64).abs()))
 }
 
-fn is_letters(interpreter: &mut Interpreter, universe: &mut Universe) {
+fn is_letters(interpreter: &mut Interpreter, _: &mut GcHeap, universe: &mut Universe) {
     const SIGNATURE: &str = "String>>#isLetters";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -86,7 +87,7 @@ fn is_letters(interpreter: &mut Interpreter, universe: &mut Universe) {
     ))
 }
 
-fn is_digits(interpreter: &mut Interpreter, universe: &mut Universe) {
+fn is_digits(interpreter: &mut Interpreter, _: &mut GcHeap, universe: &mut Universe) {
     const SIGNATURE: &str = "String>>#isDigits";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -104,7 +105,7 @@ fn is_digits(interpreter: &mut Interpreter, universe: &mut Universe) {
     ))
 }
 
-fn is_whitespace(interpreter: &mut Interpreter, universe: &mut Universe) {
+fn is_whitespace(interpreter: &mut Interpreter, _: &mut GcHeap, universe: &mut Universe) {
     const SIGNATURE: &str = "String>>#isWhiteSpace";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -122,7 +123,7 @@ fn is_whitespace(interpreter: &mut Interpreter, universe: &mut Universe) {
     ))
 }
 
-fn concatenate(interpreter: &mut Interpreter, universe: &mut Universe) {
+fn concatenate(interpreter: &mut Interpreter, heap: &mut GcHeap, universe: &mut Universe) {
     const SIGNATURE: &str = "String>>#concatenate:";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -143,10 +144,10 @@ fn concatenate(interpreter: &mut Interpreter, universe: &mut Universe) {
 
     interpreter
         .stack
-        .push(Value::String(Rc::new(format!("{}{}", s1, s2))))
+        .push(Value::String(heap.allocate(format!("{}{}", s1, s2))))
 }
 
-fn as_symbol(interpreter: &mut Interpreter, universe: &mut Universe) {
+fn as_symbol(interpreter: &mut Interpreter, _: &mut GcHeap, universe: &mut Universe) {
     const SIGNATURE: &str = "String>>#asSymbol";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -162,7 +163,7 @@ fn as_symbol(interpreter: &mut Interpreter, universe: &mut Universe) {
     }
 }
 
-fn eq(interpreter: &mut Interpreter, universe: &mut Universe) {
+fn eq(interpreter: &mut Interpreter, _: &mut GcHeap, universe: &mut Universe) {
     const SIGNATURE: &str = "String>>#=";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -191,7 +192,11 @@ fn eq(interpreter: &mut Interpreter, universe: &mut Universe) {
     interpreter.stack.push(Value::Boolean(s1 == s2))
 }
 
-fn prim_substring_from_to(interpreter: &mut Interpreter, universe: &mut Universe) {
+fn prim_substring_from_to(
+    interpreter: &mut Interpreter,
+    heap: &mut GcHeap,
+    universe: &mut Universe,
+) {
     const SIGNATURE: &str = "String>>#primSubstringFrom:to:";
 
     expect_args!(SIGNATURE, interpreter, [
@@ -206,7 +211,7 @@ fn prim_substring_from_to(interpreter: &mut Interpreter, universe: &mut Universe
         (_, _, _) => panic!("'{}': wrong types", SIGNATURE),
     };
 
-    let string = Rc::new(value.chars().skip(from).take(to - from).collect());
+    let string = heap.allocate(value.chars().skip(from).take(to - from).collect());
 
     interpreter.stack.push(Value::String(string))
 }

--- a/som-interpreter-bc/src/primitives/symbol.rs
+++ b/som-interpreter-bc/src/primitives/symbol.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use som_gc::GcHeap;
 
 use crate::interpreter::Interpreter;
 use crate::primitives::PrimitiveFn;
@@ -10,16 +10,16 @@ pub static INSTANCE_PRIMITIVES: &[(&str, PrimitiveFn, bool)] =
     &[("asString", self::as_string, true)];
 pub static CLASS_PRIMITIVES: &[(&str, PrimitiveFn, bool)] = &[];
 
-fn as_string(interpreter: &mut Interpreter, universe: &mut Universe) {
+fn as_string(interpreter: &mut Interpreter, heap: &mut GcHeap, universe: &mut Universe) {
     const SIGNATURE: &str = "Symbol>>#asString";
 
     expect_args!(SIGNATURE, interpreter, [
         Value::Symbol(sym) => sym,
     ]);
 
-    interpreter.stack.push(Value::String(Rc::new(
-        universe.lookup_symbol(sym).to_string(),
-    )));
+    interpreter.stack.push(Value::String(
+        heap.allocate(universe.lookup_symbol(sym).to_string()),
+    ));
 }
 
 /// Search for an instance primitive matching the given signature.

--- a/som-interpreter-bc/src/primitives/system.rs
+++ b/som-interpreter-bc/src/primitives/system.rs
@@ -248,7 +248,7 @@ fn full_gc(interpreter: &mut Interpreter, heap: &mut GcHeap, universe: &mut Univ
 }
 
 fn gc_stats(interpreter: &mut Interpreter, heap: &mut GcHeap, _: &mut Universe) {
-    const SIGNATURE: &str = "System>>#fullGC";
+    const SIGNATURE: &str = "System>>#gcStats";
 
     expect_args!(SIGNATURE, interpreter, [Value::System]);
 

--- a/som-interpreter-bc/src/shell.rs
+++ b/som-interpreter-bc/src/shell.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use anyhow::Error;
 
+use som_gc::GcHeap;
 use som_lexer::{Lexer, Token};
 use som_parser::lang;
 
@@ -15,6 +16,7 @@ use som_interpreter_bc::value::Value;
 
 /// Launches an interactive Read-Eval-Print-Loop within the given universe.
 pub fn interactive(
+    heap: &mut GcHeap,
     interpreter: &mut Interpreter,
     universe: &mut Universe,
     verbose: bool,
@@ -82,6 +84,7 @@ pub fn interactive(
 
         let object_class = universe.object_class();
         let class = match compiler::compile_class(
+            heap,
             &mut universe.interner,
             &class_def,
             Some(&object_class),
@@ -93,17 +96,17 @@ pub fn interactive(
             }
         };
         let metaclass_class = universe.metaclass_class();
-        class.borrow_mut().set_super_class(&object_class);
+        class.borrow_mut().set_super_class(object_class.clone());
         class
             .borrow()
             .class()
             .borrow_mut()
-            .set_super_class(&object_class.borrow().class());
+            .set_super_class(object_class.borrow().class().clone());
         class
             .borrow()
             .class()
             .borrow_mut()
-            .set_class(&metaclass_class);
+            .set_class(metaclass_class.clone());
 
         let method = class
             .borrow()
@@ -115,10 +118,10 @@ pub fn interactive(
             holder: class.clone(),
             self_value: Value::Class(class),
         };
-        let frame = interpreter.push_frame(kind);
+        let frame = interpreter.push_frame(heap, kind);
         frame.borrow_mut().args.push(Value::System);
         frame.borrow_mut().args.push(last_value.clone());
-        if let Some(value) = interpreter.run(universe) {
+        if let Some(value) = interpreter.run(heap, universe) {
             writeln!(
                 &mut stdout,
                 "returned: {} ({:?})",

--- a/som-interpreter-bc/src/value.rs
+++ b/som-interpreter-bc/src/value.rs
@@ -1,7 +1,7 @@
 use std::fmt;
-use std::rc::Rc;
 
 use num_bigint::BigInt;
+use som_gc::{Gc, Trace};
 
 use crate::block::Block;
 use crate::class::Class;
@@ -29,17 +29,50 @@ pub enum Value {
     /// An interned symbol value.
     Symbol(Interned),
     /// A string value.
-    String(Rc<String>),
+    String(Gc<String>),
     /// An array of values.
     Array(SOMRef<Vec<Self>>),
     /// A block value, ready to be evaluated.
-    Block(Rc<Block>),
+    Block(Gc<Block>),
     /// A generic (non-primitive) class instance.
     Instance(SOMRef<Instance>),
     /// A bare class object.
     Class(SOMRef<Class>),
     /// A bare invokable.
-    Invokable(Rc<Method>),
+    Invokable(Gc<Method>),
+}
+
+impl Trace for Value {
+    #[inline]
+    fn trace(&self) {
+        match self {
+            Value::Nil => {}
+            Value::System => {}
+            Value::Boolean(_) => {}
+            Value::Integer(_) => {}
+            Value::BigInteger(_) => {}
+            Value::Double(_) => {}
+            Value::Symbol(_) => {}
+            Value::String(string) => {
+                string.trace();
+            }
+            Value::Array(array) => {
+                array.trace();
+            }
+            Value::Block(block) => {
+                block.trace();
+            }
+            Value::Instance(instance) => {
+                instance.trace();
+            }
+            Value::Class(class) => {
+                class.trace();
+            }
+            Value::Invokable(method) => {
+                method.trace();
+            }
+        }
+    }
 }
 
 impl Value {
@@ -64,7 +97,7 @@ impl Value {
     }
 
     /// Search for a given method for this value.
-    pub fn lookup_method(&self, universe: &Universe, signature: Interned) -> Option<Rc<Method>> {
+    pub fn lookup_method(&self, universe: &Universe, signature: Interned) -> Option<Gc<Method>> {
         self.class(universe).borrow().lookup_method(signature)
     }
 
@@ -119,11 +152,11 @@ impl Value {
                 instance.borrow().class().borrow().name(),
             ),
             Self::Class(class) => class.borrow().name().to_string(),
-            Self::Invokable(invokable) => invokable
-                .holder()
-                .upgrade()
-                .map(|holder| format!("{}>>#{}", holder.borrow().name(), invokable.signature()))
-                .unwrap_or_else(|| format!("??>>#{}", invokable.signature())),
+            Self::Invokable(invokable) => format!(
+                "{}>>#{}",
+                invokable.holder.borrow().name(),
+                invokable.signature(),
+            ),
         }
     }
 }
@@ -143,12 +176,12 @@ impl PartialEq for Value {
                 a.eq(&BigInt::from(*b))
             }
             (Self::Symbol(a), Self::Symbol(b)) => a.eq(b),
-            (Self::String(a), Self::String(b)) => Rc::ptr_eq(a, b),
-            (Self::Array(a), Self::Array(b)) => Rc::ptr_eq(a, b),
-            (Self::Instance(a), Self::Instance(b)) => Rc::ptr_eq(a, b),
-            (Self::Class(a), Self::Class(b)) => Rc::ptr_eq(a, b),
-            (Self::Block(a), Self::Block(b)) => Rc::ptr_eq(a, b),
-            (Self::Invokable(a), Self::Invokable(b)) => Rc::ptr_eq(a, b),
+            (Self::String(a), Self::String(b)) => Gc::ptr_eq(a, b),
+            (Self::Array(a), Self::Array(b)) => Gc::ptr_eq(a, b),
+            (Self::Instance(a), Self::Instance(b)) => Gc::ptr_eq(a, b),
+            (Self::Class(a), Self::Class(b)) => Gc::ptr_eq(a, b),
+            (Self::Block(a), Self::Block(b)) => Gc::ptr_eq(a, b),
+            (Self::Invokable(a), Self::Invokable(b)) => Gc::ptr_eq(a, b),
             _ => false,
         }
     }
@@ -164,17 +197,13 @@ impl fmt::Debug for Value {
             Self::BigInteger(val) => f.debug_tuple("BigInteger").field(val).finish(),
             Self::Double(val) => f.debug_tuple("Double").field(val).finish(),
             Self::Symbol(val) => f.debug_tuple("Symbol").field(val).finish(),
-            Self::String(val) => f.debug_tuple("String").field(val).finish(),
-            Self::Array(val) => f.debug_tuple("Array").field(&val.borrow()).finish(),
-            Self::Block(val) => f.debug_tuple("Block").field(val).finish(),
+            Self::String(val) => f.debug_tuple("String").field(val.as_ref()).finish(),
+            Self::Array(val) => f.debug_tuple("Array").field(val.as_ref()).finish(),
+            Self::Block(val) => f.debug_tuple("Block").field(val.as_ref()).finish(),
             Self::Instance(val) => f.debug_tuple("Instance").field(&val.borrow()).finish(),
-            Self::Class(val) => f.debug_tuple("Class").field(&val.borrow()).finish(),
+            Self::Class(val) => f.debug_tuple("Class").field(val.as_ref()).finish(),
             Self::Invokable(val) => {
-                let signature = val
-                    .holder()
-                    .upgrade()
-                    .map(|holder| format!("{}>>#{}", holder.borrow().name(), val.signature()))
-                    .unwrap_or_else(|| format!("??>>#{}", val.signature()));
+                let signature = format!("{}>>#{}", val.holder.borrow().name(), val.signature());
                 f.debug_tuple("Invokable").field(&signature).finish()
             }
         }


### PR DESCRIPTION
This PR introduces a new crate within the `som-rs` workspace, called `som-gc`.  
It is an implementation of a mark-and-sweep garbage collector as a Rust library.  

Automatic memory management and reclamation is a quite new territory for me, as I have been reading about and researching on my free time for a while now, but never wrote anything like it yet.  
Therefore, the initial implementation in this PR is rather simple compared to what's eventually possible.  
I plan to improve the implementation as time goes on and as my knowledge of better GC techniques grows.  

This PR also already changes `som-interpreter-bc` to integrate this new GC, as a replacement of the reference-counting method that it previously used.  
The integration is already complete, all instance of reference-counting is now gone and the SOM primitives that were previously unable to be implemented (`System>>#fullGC` and `System>>#gcStats`) are now available and passing the tests.  

The performance of this GC, however, is a notable regression from reference-counting, from my initial measurements.  
Since the implementation is rather simple right now, this was to be expected and I hope to make it better progressively over time.  

The inclusion of a tracing garbage collector also allows to finally address the memory leak issue that could happen when reference cycles occurred (when two SOM values references each other, directly or indirectly).  