### PR TITLE
Fixed improper parsing of terms

### DIFF
--- a/som-core/src/ast.rs
+++ b/som-core/src/ast.rs
@@ -121,7 +121,6 @@ pub struct Body {
 /// "exit operation"     ^counter
 /// "literal"            'foo'
 /// "block"              [ :value | counter incrementBy: value ]
-/// "term"               ( counter increment )
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expression {
@@ -139,8 +138,6 @@ pub enum Expression {
     Literal(Literal),
     /// A block (eg. `[ :value | counter incrementBy: value ]`).
     Block(Block),
-    /// A term (eg. `( counter increment )`).
-    Term(Term),
 }
 
 /// Represents a message send.

--- a/som-interpreter-ast/src/evaluate.rs
+++ b/som-interpreter-ast/src/evaluate.rs
@@ -81,7 +81,6 @@ impl Evaluate for ast::Expression {
                     universe.unknown_global(self_value, name.as_str())
                 })
                 .unwrap_or_else(|| Return::Exception(format!("variable '{}' not found", name))),
-            Self::Term(term) => term.evaluate(universe),
             Self::Message(msg) => msg.evaluate(universe),
         }
     }

--- a/som-interpreter-bc/src/compiler.rs
+++ b/som-interpreter-bc/src/compiler.rs
@@ -329,11 +329,6 @@ impl MethodCodegen for ast::Expression {
                 ctxt.push_instr(Bytecode::PushBlock(idx as u8));
                 Some(())
             }
-            ast::Expression::Term(term) => term
-                .body
-                .exprs
-                .iter()
-                .try_for_each(|expr| expr.codegen(ctxt)),
         }
     }
 }

--- a/som-parser-symbols/src/lang.rs
+++ b/som-parser-symbols/src/lang.rs
@@ -262,8 +262,11 @@ pub fn block<'a>() -> impl Parser<Expression, &'a [Token]> {
 }
 
 pub fn term<'a>() -> impl Parser<Expression, &'a [Token]> {
-    between(exact(Token::NewTerm), body(), exact(Token::EndTerm))
-        .map(|body| Expression::Term(Term { body }))
+    between(
+        exact(Token::NewTerm),
+        assignment().or(expression()),
+        exact(Token::EndTerm),
+    )
 }
 
 pub fn exit<'a>() -> impl Parser<Expression, &'a [Token]> {

--- a/som-parser-symbols/tests/tests.rs
+++ b/som-parser-symbols/tests/tests.rs
@@ -105,15 +105,10 @@ fn expression_test_2() {
     assert_eq!(
         expression,
         Expression::Message(Message {
-            receiver: Box::new(Expression::Term(Term {
-                body: Body {
-                    exprs: vec![Expression::BinaryOp(BinaryOp {
-                        op: String::from("=="),
-                        lhs: Box::new(Expression::Literal(Literal::Integer(3))),
-                        rhs: Box::new(Expression::Literal(Literal::Integer(3))),
-                    })],
-                    full_stopped: false,
-                }
+            receiver: Box::new(Expression::BinaryOp(BinaryOp {
+                op: String::from("=="),
+                lhs: Box::new(Expression::Literal(Literal::Integer(3))),
+                rhs: Box::new(Expression::Literal(Literal::Integer(3))),
             })),
             signature: String::from("ifTrue:ifFalse:"),
             values: vec![
@@ -173,38 +168,19 @@ fn primary_test() {
                     signature: String::from("fib:"),
                     values: vec![Expression::BinaryOp(BinaryOp {
                         op: String::from("+"),
-                        lhs: Box::new(Expression::Term(Term {
-                            body: Body {
-                                exprs: vec![Expression::BinaryOp(BinaryOp {
-                                    op: String::from("-"),
-                                    lhs: Box::new(Expression::Reference(String::from("n"))),
-                                    rhs: Box::new(Expression::Literal(Literal::Integer(1))),
-                                })],
-                                full_stopped: false,
-                            }
+                        lhs: Box::new(Expression::BinaryOp(BinaryOp {
+                            op: String::from("-"),
+                            lhs: Box::new(Expression::Reference(String::from("n"))),
+                            rhs: Box::new(Expression::Literal(Literal::Integer(1))),
                         })),
-                        rhs: Box::new(Expression::Term(Term {
-                            body: Body {
-                                exprs: vec![Expression::Message(Message {
-                                    receiver: Box::new(Expression::Reference(String::from("self"))),
-                                    signature: String::from("fib:"),
-                                    values: vec![Expression::Term(Term {
-                                        body: Body {
-                                            exprs: vec![Expression::BinaryOp(BinaryOp {
-                                                op: String::from("-"),
-                                                lhs: Box::new(Expression::Reference(String::from(
-                                                    "n"
-                                                ))),
-                                                rhs: Box::new(Expression::Literal(
-                                                    Literal::Integer(2)
-                                                )),
-                                            })],
-                                            full_stopped: false,
-                                        }
-                                    })],
-                                })],
-                                full_stopped: false,
-                            }
+                        rhs: Box::new(Expression::Message(Message {
+                            receiver: Box::new(Expression::Reference(String::from("self"))),
+                            signature: String::from("fib:"),
+                            values: vec![Expression::BinaryOp(BinaryOp {
+                                op: String::from("-"),
+                                lhs: Box::new(Expression::Reference(String::from("n"))),
+                                rhs: Box::new(Expression::Literal(Literal::Integer(2))),
+                            })],
                         }))
                     })],
                 })],

--- a/som-parser-text/src/lang.rs
+++ b/som-parser-text/src/lang.rs
@@ -374,13 +374,10 @@ pub fn term<'a>() -> impl Parser<Expression, &'a [char]> {
     move |input: &'a [char]| {
         let (_, input) = exact('(').parse(input)?;
         let (_, input) = many(spacing()).parse(input)?;
-        let (body, input) = body().parse(input)?;
+        let (expr, input) = assignment().or(expression()).parse(input)?;
         let (_, input) = many(spacing()).parse(input)?;
         let (_, input) = exact(')').parse(input)?;
-
-        let term = Term { body };
-        let term = Expression::Term(term);
-        Some((term, input))
+        Some((expr, input))
     }
 }
 

--- a/som-parser-text/tests/tests.rs
+++ b/som-parser-text/tests/tests.rs
@@ -98,15 +98,10 @@ fn expression_test_2() {
     assert_eq!(
         expression,
         Expression::Message(Message {
-            receiver: Box::new(Expression::Term(Term {
-                body: Body {
-                    exprs: vec![Expression::BinaryOp(BinaryOp {
-                        op: String::from("=="),
-                        lhs: Box::new(Expression::Literal(Literal::Integer(3))),
-                        rhs: Box::new(Expression::Literal(Literal::Integer(3))),
-                    })],
-                    full_stopped: false,
-                }
+            receiver: Box::new(Expression::BinaryOp(BinaryOp {
+                op: String::from("=="),
+                lhs: Box::new(Expression::Literal(Literal::Integer(3))),
+                rhs: Box::new(Expression::Literal(Literal::Integer(3))),
             })),
             signature: String::from("ifTrue:ifFalse:"),
             values: vec![
@@ -166,38 +161,19 @@ fn primary_test() {
                     signature: String::from("fib:"),
                     values: vec![Expression::BinaryOp(BinaryOp {
                         op: String::from("+"),
-                        lhs: Box::new(Expression::Term(Term {
-                            body: Body {
-                                exprs: vec![Expression::BinaryOp(BinaryOp {
-                                    op: String::from("-"),
-                                    lhs: Box::new(Expression::Reference(String::from("n"))),
-                                    rhs: Box::new(Expression::Literal(Literal::Integer(1))),
-                                })],
-                                full_stopped: false,
-                            }
+                        lhs: Box::new(Expression::BinaryOp(BinaryOp {
+                            op: String::from("-"),
+                            lhs: Box::new(Expression::Reference(String::from("n"))),
+                            rhs: Box::new(Expression::Literal(Literal::Integer(1))),
                         })),
-                        rhs: Box::new(Expression::Term(Term {
-                            body: Body {
-                                exprs: vec![Expression::Message(Message {
-                                    receiver: Box::new(Expression::Reference(String::from("self"))),
-                                    signature: String::from("fib:"),
-                                    values: vec![Expression::Term(Term {
-                                        body: Body {
-                                            exprs: vec![Expression::BinaryOp(BinaryOp {
-                                                op: String::from("-"),
-                                                lhs: Box::new(Expression::Reference(String::from(
-                                                    "n"
-                                                ))),
-                                                rhs: Box::new(Expression::Literal(
-                                                    Literal::Integer(2)
-                                                )),
-                                            })],
-                                            full_stopped: false,
-                                        }
-                                    })],
-                                })],
-                                full_stopped: false,
-                            }
+                        rhs: Box::new(Expression::Message(Message {
+                            receiver: Box::new(Expression::Reference(String::from("self"))),
+                            signature: String::from("fib:"),
+                            values: vec![Expression::BinaryOp(BinaryOp {
+                                op: String::from("-"),
+                                lhs: Box::new(Expression::Reference(String::from("n"))),
+                                rhs: Box::new(Expression::Literal(Literal::Integer(2))),
+                            })],
                         }))
                     })],
                 })],


### PR DESCRIPTION
Before this PR, `som-rs` treated terms the same as method (or block) bodies, but without the locals declaration part.  
This meant that we accepted multiple expressions within a single term by separating them with dots, like so:

```plaintext
(0) SOM Shell | (1. 2)
returned: 2 (Integer(2))
(1) SOM Shell | ('Hello there !' println. 'Obi-Wan Kenobi')
Hello there !
returned: Obi-Wan Kenobi (String("Obi-Wan Kenobi"))
```

This PR fixes this in both parsers (`som-parser-symbols` and `som-parser-text`) to only allow a single expression or assignment (like `a := 1`), to get in line with other SOMs.  

This also means terms simply resolve into their single inner expression and so we get rid of the `Expression::Term` enum variant in the AST from `som-core` (and therefore also remove their evaluation paths in both of our VMs).  