### PR TITLE
CI fixes for ReBench v1.1.0

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -33,4 +33,4 @@ jobs:
       - name: Run and report benchmarks
         run: |
           export PATH="${PATH}:${HOME}/.local/bin"
-          rebench --without-nice --experiment="CI Benchmark Run ID ${GITHUB_RUN_ID}" --branch="${GITHUB_REF}" -c rebench.conf som-rs
+          rebench --experiment="CI Benchmark Run ID ${GITHUB_RUN_ID}" --branch="${GITHUB_REF}" -c rebench.conf som-rs

--- a/rebench.conf
+++ b/rebench.conf
@@ -7,7 +7,7 @@ reporting:
     # Benchmark results will be reported to ReBenchDB
     rebenchdb:
         # this url needs to point to the API endpoint
-        db_url: https://rebench.polomack.eu/rebenchdb/results
+        db_url: https://rebench.polomack.eu/rebenchdb
         repo_url: https://github.com/Hirevo/som-rs
         record_all: true # make sure everything is recorded
         project_name: som-rs


### PR DESCRIPTION
This PR fixes the CI workflow to account for the release of ReBench v1.1.0, which dropped the `--without-nice` command-line option.  