### PR TITLE
Custom Cargo profile settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /.vscode
 /.nova
 /.idea
+
+# Folder to put files not intended to be pushed (like temporary files)
+/ignored

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,21 @@ members = [
     "som-parser-symbols",
     "som-parser-text",
 ]
+
+[profile.release]
+# Enable link-time optimization, eliminates more code and inlines across crate boundaries.
+# Default: false
+lto = "fat"
+# codegen-units of 1 gives best optimization, but disables parallel building.
+# Default: 16
+codegen-units = 1
+# The default optimization level is 3 for release mode builds.
+# 0 means disable optimization and is the default for debug mode buids.
+# (Setting opt-level=1 for debug builds is a good way of speeding them up a bit.)
+# "s" means optimize for size, "z" reduces size even more.
+opt-level = 3
+
+[profile.release-dbg]
+inherits = "release"
+# Includes debug information in release builds. Necessary for profiling.
+debug = true


### PR DESCRIPTION
This PR changes some profile settings for the `release` profile and adds a new `release-dbg` profile to allow for optimised builds with debug symbols.

The most important change is that it enables LTO (link time optimisation), allowing the linker to optimise across crate boundaries.

I did some benchmarking and it does seem to improve the performance a tiny bit (about 5 % faster on average):

<img width="877" alt="image" src="https://github.com/Hirevo/som-rs/assets/4294633/5c5fc4e5-f202-4d7e-ba46-15b4b101ab6e">

> `before-profile-opts` is the from current `master` branch.
> `after-profile-opts` is with the newly added settings.
> Both were compiled with the `release` profile.