### PR TITLE
Migrate from structopt to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,17 +45,41 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -92,12 +107,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -140,12 +152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +186,18 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "ppv-lite86"
@@ -278,6 +296,7 @@ name = "som-interpreter-ast"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "indexmap",
  "jemallocator",
  "num-bigint",
@@ -286,7 +305,6 @@ dependencies = [
  "som-core",
  "som-lexer",
  "som-parser-symbols",
- "structopt",
 ]
 
 [[package]]
@@ -294,6 +312,7 @@ name = "som-interpreter-bc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "indexmap",
  "jemallocator",
  "num-bigint",
@@ -302,7 +321,6 @@ dependencies = [
  "som-core",
  "som-lexer",
  "som-parser-symbols",
- "structopt",
 ]
 
 [[package]]
@@ -332,33 +350,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -372,37 +366,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
+name = "textwrap"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -431,6 +413,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/som-interpreter-ast/Cargo.toml
+++ b/som-interpreter-ast/Cargo.toml
@@ -15,7 +15,7 @@ som-parser = { package = "som-parser-symbols", path = "../som-parser-symbols", v
 # som-parser = { package = "som-parser-text", path = "../som-parser-text", version = "0.1.0" }
 
 # CLI interface
-structopt = "0.3.25"
+clap = { version = "3.0", features = ["derive"] }
 
 # error handling
 anyhow = "1.0.51"

--- a/som-interpreter-ast/src/main.rs
+++ b/som-interpreter-ast/src/main.rs
@@ -7,9 +7,9 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use anyhow::anyhow;
+use clap::Parser;
 #[cfg(feature = "jemalloc")]
 use jemallocator::Jemalloc;
-use structopt::StructOpt;
 
 mod shell;
 
@@ -21,22 +21,22 @@ use som_interpreter_ast::value::Value;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-#[derive(Debug, Clone, PartialEq, StructOpt)]
+#[derive(Debug, Clone, PartialEq, clap::StructOpt)]
 #[structopt(about, author)]
 struct Options {
     /// Files to evaluate.
-    #[structopt(name = "FILE")]
+    #[clap(name = "FILE")]
     file: Option<PathBuf>,
 
-    #[structopt(name = "ARGS")]
+    #[clap(name = "ARGS")]
     args: Vec<String>,
 
     /// Set search path for application classes.
-    #[structopt(short, long)]
+    #[clap(short, long, multiple_values(true))]
     classpath: Vec<PathBuf>,
 
     /// Enable verbose output (with timing information).
-    #[structopt(short = "v")]
+    #[clap(short = 'v')]
     verbose: bool,
 }
 

--- a/som-interpreter-bc/Cargo.toml
+++ b/som-interpreter-bc/Cargo.toml
@@ -15,7 +15,7 @@ som-parser = { package = "som-parser-symbols", path = "../som-parser-symbols", v
 # som-parser = { package = "som-parser-text", path = "../som-parser-text", version = "0.1.0" }
 
 # CLI interface
-structopt = "0.3.25"
+clap = { version = "3.0", features = ["derive"] }
 
 # error handling
 anyhow = "1.0.51"

--- a/som-interpreter-bc/src/main.rs
+++ b/som-interpreter-bc/src/main.rs
@@ -7,9 +7,9 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use anyhow::{bail, Context};
+use clap::Parser;
 #[cfg(feature = "jemalloc")]
 use jemallocator::Jemalloc;
-use structopt::StructOpt;
 
 mod shell;
 
@@ -23,8 +23,8 @@ use som_interpreter_bc::value::Value;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-#[derive(Debug, Clone, PartialEq, StructOpt)]
-#[structopt(about, author)]
+#[derive(Debug, Clone, PartialEq, clap::StructOpt)]
+#[clap(about, author)]
 struct Options {
     /// File to evaluate.
     file: Option<PathBuf>,
@@ -33,15 +33,15 @@ struct Options {
     args: Vec<String>,
 
     /// Set search path for application classes.
-    #[structopt(long, short)]
+    #[clap(long, short, multiple_values(true))]
     classpath: Vec<PathBuf>,
 
     /// Disassemble the class, instead of executing.
-    #[structopt(long, short)]
+    #[clap(long, short)]
     disassemble: bool,
 
     /// Enable verbose output (with timing information).
-    #[structopt(short = "v")]
+    #[clap(short = 'v')]
     verbose: bool,
 }
 


### PR DESCRIPTION
Structopt is no longer maintained and its functionality has been merged into clap-v3. Migrating to the latter means that som-rs will no longer fail with the cargo security audit tool [1].

[1]: https://crates.io/crates/cargo-audit