### PR TITLE
Add interpreter microbenchmarks

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -54,6 +54,29 @@ benchmark_suites:
             - WhileLoop:    {extra_args: 10}
             - Mandelbrot:   {extra_args: 30}
 
+    interpreter:
+        description: Basic interpreter benchmarks for comparing performance of most basic concepts.
+        gauge_adapter: RebenchLog
+        invocations: 5
+        command: "-c core-lib/Smalltalk core-lib/Examples/Benchmarks/Interpreter core-lib/Examples/Benchmarks -- BenchmarkHarness %(benchmark)s %(iterations)s 1"
+        benchmarks:
+            - ArgRead
+            - ArrayReadConst
+            - ArrayWriteConstConst
+            - BlockSend0ConstReturn
+            - Const
+            - FieldConstWrite
+            - FieldRead
+            - FieldReadIncWrite
+            - FieldReadWrite
+            - GlobalRead
+            - LocalConstWrite
+            - LocalRead
+            - LocalReadIncWrite
+            - LocalReadWrite
+            - SelfSend0
+            - SelfSend0BlockConstNonLocalReturn
+
 executors:
     som-rs-ast:
         path: .
@@ -69,6 +92,7 @@ experiments:
         suites:
             - micro
             - macro
+            - interpreter
         executions:
             - som-rs-ast
             - som-rs-bc


### PR DESCRIPTION
The main purpose of the PR is to add interpreter microbenchmarks.
Though, it also updates the core-lib to the [latest version](https://github.com/SOM-st/SOM/pull/121).